### PR TITLE
Dev/tw/open gl viewer

### DIFF
--- a/newton/_src/solvers/kamino/core/builder.py
+++ b/newton/_src/solvers/kamino/core/builder.py
@@ -223,7 +223,7 @@ class ModelBuilder:
             ValueError: If the inertia matrix is not symmetric of positive definite.
         """
         i_I_i_np = np.ndarray(buffer=i_I_i, shape=(3, 3), dtype=np.float32)
-        if not np.allclose(i_I_i_np, i_I_i_np.T, atol=FLOAT32_EPS):
+        if not np.allclose(i_I_i_np, i_I_i_np.T, atol=float(FLOAT32_EPS)):
             raise ValueError(f"Invalid body inertia matrix:\n{i_I_i}\nMust be symmetric.")
         if not np.all(np.linalg.eigvals(i_I_i_np) > 0.0):
             raise ValueError(f"Invalid body inertia matrix:\n{i_I_i}\nMust be positive definite.")
@@ -243,7 +243,7 @@ class ModelBuilder:
             raise TypeError(f"Invalid body pose type: {type(q_i)}. Must be `transformf`.")
 
         # Extract the orientation quaterion
-        if not np.isclose(wp.length(q_i.q), 1.0, atol=FLOAT32_EPS):
+        if not np.isclose(wp.length(q_i.q), 1.0, atol=float(FLOAT32_EPS)):
             raise ValueError(
                 f"Invalid body pose orientation quaternion: {q_i.q}. "
                 "Must be a unit quaternion."

--- a/newton/_src/solvers/kamino/examples/sim/boxes_fourbar.py
+++ b/newton/_src/solvers/kamino/examples/sim/boxes_fourbar.py
@@ -1,33 +1,30 @@
+import argparse
 import os
 import time
-import h5py
 
+import h5py
 import numpy as np
 import warp as wp
 
+import newton
+import newton.examples
 import newton._src.solvers.kamino.utils.logger as msg
-from newton._src.solvers.kamino.core.types import float32, vec3f, vec6f, mat33f, transformf
-from newton._src.solvers.kamino.core.math import R_x, R_y, R_z, screw
 from newton._src.solvers.kamino.core.builder import ModelBuilder
-from newton._src.solvers.kamino.utils.io import hdf5
-from newton._src.solvers.kamino.utils.io.usd import USDImporter
-from newton._src.solvers.kamino.simulation.simulator import Simulator
-from newton._src.solvers.kamino.utils.print import print_progress_bar
-from newton._src.solvers.kamino.utils.profile import get_device_info
-from newton._src.solvers.kamino.models import get_primitives_usd_assets_path
-from newton._src.solvers.kamino.models.builders import (
-    add_ground_geom,
-    add_velocity_bias,
-    offset_builder,
-    build_boxes_fourbar
-)
+from newton._src.solvers.kamino.core.types import float32, vec6f
 from newton._src.solvers.kamino.examples import (
-    get_examples_data_root_path,
     get_examples_data_hdf5_path,
     print_frame
 )
-
-from newton._src.solvers.kamino.tests.test_solvers_padmm import save_solver_info
+from newton._src.solvers.kamino.models import get_primitives_usd_assets_path
+from newton._src.solvers.kamino.models.builders import (
+    add_ground_geom,
+    build_boxes_fourbar
+)
+from newton._src.solvers.kamino.simulation.simulator import Simulator
+from newton._src.solvers.kamino.utils.io import hdf5
+from newton._src.solvers.kamino.utils.io.usd import USDImporter
+from newton._src.solvers.kamino.utils.print import print_progress_bar
+from newton._src.solvers.kamino.utils.profile import get_device_info
 
 
 ###
@@ -101,17 +98,8 @@ RENDER_DATASET_PATH = os.path.join(get_examples_data_hdf5_path(), "fourbar_free.
 # Main function
 ###
 
-if __name__ == "__main__":
-
-    msg.info("This example has been disabled temporarily.")
-
-    # TODO: load these from arguments
-    # Application options
-    clear_warp_cache = True
-    use_cuda_graph = False
-    load_from_usd = False
-    verbose = False
-
+def run_hdf5_mode(clear_warp_cache=True, use_cuda_graph=False, load_from_usd=False, verbose=False):
+    """Run the simulation in HDF5 mode to save data to file."""
     # Clear the warp caches
     if clear_warp_cache:
         wp.clear_kernel_cache()
@@ -250,3 +238,199 @@ if __name__ == "__main__":
     # Save the dataset
     msg.info("Saving all frames to HDF5...")
     renderer.save()
+
+
+class BoxesFourbarExample:
+    """ViewerGL example class for boxes fourbar simulation."""
+
+    def __init__(self, viewer, load_from_usd=False):
+        self.fps = 60
+        self.frame_dt = 1.0 / self.fps
+        self.sim_time = 0.0
+        self.sim_substeps = 10
+        self.sim_dt = self.frame_dt / self.sim_substeps
+
+        self.viewer = viewer
+
+        # Get the default warp device
+        device = wp.get_preferred_device()
+        device = wp.get_device(device)
+
+        # Create a single-instance system
+        if load_from_usd:
+            msg.info("Constructing builder from imported USD ...")
+            importer = USDImporter()
+            builder: ModelBuilder = importer.import_from(source=USD_MODEL_PATH)
+        else:
+            msg.info("Constructing builder using generator ...")
+            builder = ModelBuilder()
+            build_boxes_fourbar(builder=builder, z_offset=0.2, ground=False)
+
+        # Add a static collision layer and geometry for the plane
+        add_ground_geom(builder)
+
+        # Set gravity
+        builder.gravity.enabled = True
+
+        # Create a simulator
+        msg.info("Building the simulator...")
+        self.sim = Simulator(builder=builder, device=device)
+        self.sim.set_control_callback(control_callback)
+
+        # Create a simple newton model just for the viewer (with ground plane)
+        newton_builder = newton.ModelBuilder()
+        newton_builder.add_ground_plane()
+        newton_model = newton_builder.finalize()
+        self.viewer.set_model(newton_model)
+
+        # Define box dimensions (from build_boxes_fourbar function)
+        # Box 1: horizontal bar (d_1=0.1, w_1=0.01, h_1=0.01)
+        # Box 2: vertical bar (d_2=0.01, w_2=0.01, h_2=0.1)  
+        # Box 3: horizontal bar (d_3=0.1, w_3=0.01, h_3=0.01)
+        # Box 4: vertical bar (d_4=0.01, w_4=0.01, h_4=0.1)
+        self.box_dimensions = [
+            (0.1, 0.01, 0.01),  # Box 1 - horizontal
+            (0.01, 0.01, 0.1),  # Box 2 - vertical
+            (0.1, 0.01, 0.01),  # Box 3 - horizontal
+            (0.01, 0.01, 0.1),  # Box 4 - vertical
+        ]
+
+        # Define diverse colors for each box
+        self.box_colors = [
+            wp.array([wp.vec3(0.9, 0.1, 0.3)], dtype=wp.vec3),  # Crimson Red
+            wp.array([wp.vec3(0.1, 0.7, 0.9)], dtype=wp.vec3),  # Cyan Blue
+            wp.array([wp.vec3(1.0, 0.5, 0.0)], dtype=wp.vec3),  # Orange
+            wp.array([wp.vec3(0.6, 0.2, 0.8)], dtype=wp.vec3),  # Purple
+        ]
+
+        # No need for custom ground color - using newton's standard ground plane
+
+        # Initialize the simulator with a warm-up step
+        self.sim.reset()
+        
+        # Don't capture graphs initially to avoid CUDA stream conflicts
+        self.graph = None
+
+    def capture(self):
+        """Capture CUDA graph if available."""
+        # For now, disable CUDA graph capture to avoid stream conflicts
+        # This can be re-enabled later if needed with proper stream management
+        self.graph = None
+
+    def simulate(self):
+        """Run simulation substeps."""
+        for _ in range(self.sim_substeps):
+            self.sim.step()
+
+    def step(self):
+        """Step the simulation."""
+        if self.graph:
+            wp.capture_launch(self.graph)
+        else:
+            self.simulate()
+
+        self.sim_time += self.frame_dt
+
+    def render(self):
+        """Render the current frame."""
+        self.viewer.begin_frame(self.sim_time)
+
+        # Extract body poses from the kamino simulator
+        try:
+            body_poses = self.sim.model_data.bodies.q_i.numpy()
+            
+            # Debug: print body poses info for first few frames
+            if self.sim_time < 0.1:
+                print(f"Number of bodies: {len(body_poses)}")
+                print(f"Body poses shape: {body_poses.shape}")
+                if len(body_poses) > 0:
+                    print(f"First body pose: {body_poses[0]}")
+
+            # Render each box using log_shapes
+            for i, (dimensions, color) in enumerate(zip(self.box_dimensions, self.box_colors)):
+                if i < len(body_poses):
+                    # Convert kamino transformf to warp transform
+                    pose = body_poses[i]
+                    # kamino transformf has [x, y, z, qx, qy, qz, qw] format
+                    position = wp.vec3(float(pose[0]), float(pose[1]), float(pose[2]))
+                    quaternion = wp.quat(float(pose[3]), float(pose[4]), float(pose[5]), float(pose[6]))
+                    transform = wp.transform(position, quaternion)
+
+                    # Log the box shape
+                    self.viewer.log_shapes(
+                        f"/fourbar/box_{i+1}",
+                        newton.GeoType.BOX,
+                        dimensions,
+                        wp.array([transform], dtype=wp.transform),
+                        color,
+                    )
+                    
+                    # Debug: print transform info for first few frames
+                    if self.sim_time < 0.1:
+                        print(f"Box {i+1}: pos={position}, quat={quaternion}")
+
+        except Exception as e:
+            print(f"Error accessing body poses: {e}")
+            print(f"Available attributes: {dir(self.sim.model_data.bodies)}")
+
+        self.viewer.end_frame()
+
+    def test(self):
+        """Test function for compatibility."""
+        pass
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Boxes fourbar simulation example")
+    parser.add_argument(
+        "--mode",
+        choices=["hdf5", "viewer"],
+        default="viewer",
+        help="Simulation mode: 'hdf5' for data collection, 'viewer' for live visualization"
+    )
+    parser.add_argument("--clear-cache", action="store_true", default=True, help="Clear warp cache")
+    parser.add_argument("--cuda-graph", action="store_true", help="Use CUDA graphs")
+    parser.add_argument("--load-from-usd", action="store_true", help="Load model from USD file")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose output")
+
+    # Add viewer arguments when in viewer mode
+    parser.add_argument("--viewer", choices=["gl", "usd", "rerun", "null"], default="gl", help="Viewer type")
+    parser.add_argument("--headless", action="store_true", help="Run in headless mode")
+    parser.add_argument("--device", type=str, help="Compute device")
+    parser.add_argument("--output-path", type=str, help="Output path for USD viewer")
+    parser.add_argument("--num-frames", type=int, default=1000, help="Number of frames for null/USD viewer")
+
+    args = parser.parse_args()
+
+    if args.mode == "hdf5":
+        msg.info("Running in HDF5 mode...")
+        run_hdf5_mode(
+            clear_warp_cache=args.clear_cache,
+            use_cuda_graph=args.cuda_graph,
+            load_from_usd=args.load_from_usd,
+            verbose=args.verbose
+        )
+    elif args.mode == "viewer":
+        msg.info("Running in ViewerGL mode...")
+
+        # Set device if specified
+        if args.device:
+            wp.set_device(args.device)
+
+        # Create viewer based on type
+        if args.viewer == "gl":
+            viewer = newton.viewer.ViewerGL(headless=args.headless)
+        elif args.viewer == "usd":
+            if args.output_path is None:
+                raise ValueError("--output-path is required when using usd viewer")
+            viewer = newton.viewer.ViewerUSD(output_path=args.output_path, num_frames=args.num_frames)
+        elif args.viewer == "rerun":
+            viewer = newton.viewer.ViewerRerun()
+        elif args.viewer == "null":
+            viewer = newton.viewer.ViewerNull(num_frames=args.num_frames)
+        else:
+            raise ValueError(f"Invalid viewer: {args.viewer}")
+
+        # Create and run example
+        example = BoxesFourbarExample(viewer, load_from_usd=args.load_from_usd)
+        newton.examples.run(example)


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
Sample that shows how the OpenGL viewer for 4 bar can be used. If the approach is fine, I'll implement it for the remaining examples as well.
You can use (the first one is the default)
python boxes_fourbar.py --mode viewer
or
python boxes_fourbar.py --mode hdf5

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
