### PR TITLE
Argparse Boolean Options

### DIFF
--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
@@ -269,15 +269,23 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A demo of all supported joint types.")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-steps", type=int, default=1000, help="Number of steps for headless mode")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=True, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=True, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
@@ -310,17 +310,27 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Box-on-Plane simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=1, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=2000, help="Number of steps for headless mode")
-    parser.add_argument("--load-from-usd", action="store_true", default=True, help="Load model from USD file")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=True, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--load-from-usd", action=argparse.BooleanOptionalAction, default=True, help="Load model from USD file"
+    )
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=True, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
@@ -317,17 +317,27 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Box-Pendulum simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=1, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=10000, help="Number of steps for headless mode")
-    parser.add_argument("--load-from-usd", action="store_true", default=True, help="Load model from USD file")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=True, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--load-from-usd", action=argparse.BooleanOptionalAction, default=True, help="Load model from USD file"
+    )
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=True, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
@@ -296,17 +296,27 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Boxes-Fourbar simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=1, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=3000, help="Number of steps for headless mode")
-    parser.add_argument("--load-from-usd", action="store_true", default=True, help="Load model from USD file")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=True, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--load-from-usd", action=argparse.BooleanOptionalAction, default=True, help="Load model from USD file"
+    )
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=True, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
@@ -295,17 +295,27 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Boxes-Hinged simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=1, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=5000, help="Number of steps for headless mode")
-    parser.add_argument("--load-from-usd", action="store_true", default=True, help="Load model from USD file")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=True, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--load-from-usd", action=argparse.BooleanOptionalAction, default=True, help="Load model from USD file"
+    )
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=True, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
@@ -605,17 +605,27 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Cartpole simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=4, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=5000, help="Number of steps for headless mode")
-    parser.add_argument("--load-from-usd", action="store_true", default=True, help="Load model from USD file")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=False, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--load-from-usd", action=argparse.BooleanOptionalAction, default=True, help="Load model from USD file"
+    )
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=False, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
@@ -312,16 +312,24 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="DR Legs simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=1, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=1000, help="Number of steps for headless mode")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=True, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=True, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
@@ -238,15 +238,21 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="DR Test Mechanism simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=1, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=1000, help="Number of steps for headless mode")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_geoms.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_geoms.py
@@ -278,11 +278,11 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A demo of all supported joint types.")
     parser.add_argument("--num-steps", type=int, default=1000, help="Number of steps for headless mode")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--pipeline-name",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
@@ -267,15 +267,23 @@ class Example:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="A demo of all supported joint types.")
     parser.add_argument("--device", type=str, help="The compute device to use")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-steps", type=int, default=1000, help="Number of steps for headless mode")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=False, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=False, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_usd_generic.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_usd_generic.py
@@ -228,16 +228,24 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="DR Legs simulation example")
     parser.add_argument("--device", type=str, help="The compute device to use")
     parser.add_argument("--usd-model-path", type=str, required=True, help="Path to the USD model to simulate")
-    parser.add_argument("--headless", action="store_true", default=False, help="Run in headless mode")
+    parser.add_argument("--headless", action=argparse.BooleanOptionalAction, default=False, help="Run in headless mode")
     parser.add_argument("--num-worlds", type=int, default=1, help="Number of worlds to simulate in parallel")
     parser.add_argument("--num-steps", type=int, default=1000, help="Number of steps for headless mode")
-    parser.add_argument("--gravity", action="store_true", default=True, help="Enables gravity in the simulation")
-    parser.add_argument("--ground", action="store_true", default=True, help="Adds a ground plane to the simulation")
-    parser.add_argument("--cuda-graph", action="store_true", default=True, help="Use CUDA graphs")
-    parser.add_argument("--clear-cache", action="store_true", default=False, help="Clear warp cache")
-    parser.add_argument("--logging", action="store_true", default=True, help="Enable logging of simulation data")
-    parser.add_argument("--show-plots", action="store_true", default=False, help="Show plots of logging data")
-    parser.add_argument("--test", action="store_true", default=False, help="Run tests")
+    parser.add_argument(
+        "--gravity", action=argparse.BooleanOptionalAction, default=True, help="Enables gravity in the simulation"
+    )
+    parser.add_argument(
+        "--ground", action=argparse.BooleanOptionalAction, default=True, help="Adds a ground plane to the simulation"
+    )
+    parser.add_argument("--cuda-graph", action=argparse.BooleanOptionalAction, default=True, help="Use CUDA graphs")
+    parser.add_argument("--clear-cache", action=argparse.BooleanOptionalAction, default=False, help="Clear warp cache")
+    parser.add_argument(
+        "--logging", action=argparse.BooleanOptionalAction, default=True, help="Enable logging of simulation data"
+    )
+    parser.add_argument(
+        "--show-plots", action=argparse.BooleanOptionalAction, default=False, help="Show plots of logging data"
+    )
+    parser.add_argument("--test", action=argparse.BooleanOptionalAction, default=False, help="Run tests")
     parser.add_argument(
         "--record",
         type=str,


### PR DESCRIPTION
<!--
Thank you for contributing to Newton!

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
Use boolean options for `ArgumentParser` to allow disabling boolean options that are defaulted to true. E.g. `--no-cuda-graph` to disable CUDA graph.

## Newton Migration Guide

Please ensure the migration guide for **warp.sim** users is up-to-date with the changes made in this PR.

- [ ] The migration guide in ``docs/migration.rst`` is up-to date

## Before your PR is "Ready for review"

- [ ] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [ ] Documentation is up-to-date
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
