### PR TITLE
fix revolute joint residual and coordinate computation

### DIFF
--- a/newton/_src/solvers/kamino/core/math.py
+++ b/newton/_src/solvers/kamino/core/math.py
@@ -532,6 +532,22 @@ def quat_conj_normalized_apply(q: quatf, v: vec3f) -> vec3f:
     return v - q[3] * uv_s + wp.cross(qv, uv_s)
 
 
+@wp.func
+def quat_twist_angle(q: quatf, axis: vec3f) -> wp.float32:
+    """
+    Computes the twist angle of a quaternion around a specific axis.
+
+    This function isolates the rotation component of ``q`` that occurs purely
+    around the provided ``axis`` (Twist-Swing decomposition) and returns
+    its angle in [-pi, pi].
+    """
+    # positive quaternion guarantees angle is in [-pi, pi]
+    p = quat_positive(q)
+    pv = quat_imaginary(p)
+    angle = 2.0 * wp.atan2(wp.dot(pv, axis), p.w)
+    return angle
+
+
 ###
 # Unit Quaternions
 ###


### PR DESCRIPTION
- Fixes some oscillations seen in the original constraint stabilization by changing the way the constraint residual is computed for revolute joints.
- Refines the state -> joint angle mapping by only measuring rotation around the x-axis, and not counting rotation due to constraint errors.

Clear improvements on revolute test example. Tested briefly for DR Legs, but no obvious differences.