### PR TITLE
fix integrator wind-up limits

### DIFF
--- a/newton/_src/solvers/kamino/utils/control/pid.py
+++ b/newton/_src/solvers/kamino/utils/control/pid.py
@@ -246,7 +246,8 @@ def _compute_jointspace_pid_control(
 
         # Update the integrator state with anti-windup clamping
         integrator += q_j_err * dt
-        integrator = wp.clamp(integrator, -tau_j_max, tau_j_max)
+        integrator_max = tau_j_max / K_i
+        integrator = wp.clamp(integrator, -integrator_max, integrator_max)
 
         # Compute the Feed-Forward + PID control generalized forces
         # NOTE: We also clamp the final control forces to avoid exceeding actuator limits


### PR DESCRIPTION
I believe this was the original intention of the anti-wind-up. To limit it at the offset where it would result in tau_j_max.