### PR TITLE
Fix non-deterministic broadphase test

### DIFF
--- a/newton/_src/solvers/kamino/tests/test_geometry_primitive.py
+++ b/newton/_src/solvers/kamino/tests/test_geometry_primitive.py
@@ -243,9 +243,12 @@ def test_broadphase(
 
     # Run per-collision checks
     if expected_worlds is not None:
+        # Sort worlds since ordering of result might not be deterministic
+        expected_worlds_sorted = np.sort(expected_worlds)
+        actual_worlds_sorted = np.sort(broadphase._cdata.wid.numpy()[:num_model_collisions])
         np.testing.assert_array_equal(
-            actual=broadphase._cdata.wid.numpy()[:num_model_collisions],
-            desired=expected_worlds,
+            actual=actual_worlds_sorted,
+            desired=expected_worlds_sorted,
             err_msg=f"\n{broadphase_type.__name__}: Failed `wid` check for {case_name}\n",
         )
 


### PR DESCRIPTION
## Description

This fixes the issue of the broadphase tests occasionally failing due to the non-deterministic result. The ordering of the collisions is not fixed, so the comparison between the actual `wid`s and the expected `wid`s might fail.

The tests now sort the list of expected and actual `wid`s so that the check is deterministic.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
