### PR TITLE
Optimize collision pair candidate computation

### DIFF
--- a/newton/_src/solvers/kamino/core/builder.py
+++ b/newton/_src/solvers/kamino/core/builder.py
@@ -1503,6 +1503,12 @@ class ModelBuilder:
         model_pairid = []
         model_wid = []
 
+        joint_idx_min = [len(self.joints)] * nw
+        joint_idx_max = [0] * nw
+        for i, joint in enumerate(self.joints):
+            joint_idx_min[joint.wid] = min(i, joint_idx_min[joint.wid])
+            joint_idx_max[joint.wid] = max(i, joint_idx_max[joint.wid])
+
         # Iterate over each world and construct the collision geometry pairs info
         ncg_offset = 0
         for wid in range(nw):
@@ -1536,10 +1542,14 @@ class ModelBuilder:
                 # 4. Check for collision according to the collision groupings
                 are_collidable = ((geom1.group & geom2.collides) != 0) and ((geom2.group & geom1.collides) != 0)
 
+                # Skip this pair if it does not pass the first round of filtering
+                if is_self_collision or not in_same_world or not are_collidable:
+                    continue
+
                 # 5. Check for neighbor collision for fixed and DoF joints
                 are_fixed_neighbors = False
                 are_dof_neighbors = False
-                for joint in self.joints:
+                for joint in self.joints[joint_idx_min[wid1] : joint_idx_max[wid1] + 1]:
                     if (joint.bid_B == bid1 and joint.bid_F == bid2) or (joint.bid_B == bid2 and joint.bid_F == bid1):
                         if joint.dof_type == JointDoFType.FIXED:
                             are_fixed_neighbors = True
@@ -1550,7 +1560,7 @@ class ModelBuilder:
                         break
 
                 # Assign pairid based on filtering results
-                if (not is_self_collision) and (in_same_world) and (are_collidable) and (not are_fixed_neighbors):
+                if not are_fixed_neighbors:
                     pairid = -1  # TODO: Compute as geom-pair key
                 else:
                     continue  # Skip this pair if it does not pass the filtering


### PR DESCRIPTION
## Description

This PR introduces some optimization for the computation of collision pair candidates for multiple worlds in the Kamino `ModelBuilder`.

### Details

The original code was checking whether two bodies were neighbors by going through all joints of all worlds. Since inter-world collisions are not possible anyway, most of this loop is unnecessary if there is more than one world. The optimized version now stores the start and end index of the joints of each world, so that the loop only needs to go over a specific interval of the joints. Additionally, we can skip the loop entirely if we already know that we filter out the collision pair (i.e., if it is a self-collision or the bodies are not collidable).

### Performance

For Dr. Legs with 1024 worlds, the call to `make_collision_candidate_pairs()` went from 53 seconds to 0.07 seconds.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
