### PR TITLE
Add interfacing of Control container with `ModelData.joints` to propagate PD+FF references

### DIFF
--- a/newton/_src/solvers/kamino/core/control.py
+++ b/newton/_src/solvers/kamino/core/control.py
@@ -45,6 +45,27 @@ class Control:
     where ``d_j`` is the number of DoFs of each joint ``j``.
     """
 
+    q_j_ref: wp.array | None = None
+    """
+    Array of reference generalized joint coordinates for implicit PD control.\n
+    Shape of ``(sum(c_j),)`` and type :class:`float`,
+    where ``c_j`` is the number of coordinates of joint ``j``.
+    """
+
+    dq_j_ref: wp.array | None = None
+    """
+    Array of reference generalized joint velocities for implicit PD control.\n
+    Shape of ``(sum(d_j),)`` and type :class:`float`,
+    where ``d_j`` is the number of DoFs of joint ``j``.
+    """
+
+    tau_j_ref: wp.array | None = None
+    """
+    Array of reference feed-forward generalized joint forces for implicit PD control.\n
+    Shape of ``(sum(d_j),)`` and type :class:`float`,
+    where ``d_j`` is the number of DoFs of joint ``j``.
+    """
+
     def copy_to(self, other: Control) -> None:
         """
         Copies the Control data to another Control object.

--- a/newton/_src/solvers/kamino/core/model.py
+++ b/newton/_src/solvers/kamino/core/model.py
@@ -995,7 +995,10 @@ class Model:
         # Create a new control container on the specified device
         with wp.ScopedDevice(device=device):
             control = Control(
-                tau_j=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=float32, requires_grad=requires_grad)
+                tau_j=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=float32, requires_grad=requires_grad),
+                q_j_ref=wp.zeros(shape=self.size.sum_of_num_joint_coords, dtype=float32, requires_grad=requires_grad),
+                dq_j_ref=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=float32, requires_grad=requires_grad),
+                tau_j_ref=wp.zeros(shape=self.size.sum_of_num_joint_dofs, dtype=float32, requires_grad=requires_grad),
             )
 
         # Return the constructed control container

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
@@ -73,8 +73,9 @@ def _pd_control_callback(
     animation_q_j_ref: wp.array2d(dtype=float32),
     animation_dq_j_ref: wp.array2d(dtype=float32),
     # Outputs:
-    data_joint_q_j_ref: wp.array(dtype=float32),
-    data_joint_dq_j_ref: wp.array(dtype=float32),
+    control_q_j_ref: wp.array(dtype=float32),
+    control_dq_j_ref: wp.array(dtype=float32),
+    control_tau_j_ref: wp.array(dtype=float32),
 ):
     """
     A kernel to compute joint-space PID control outputs for force-actuated joints.
@@ -124,11 +125,12 @@ def _pd_control_callback(
     for coord in range(num_coords_j):
         joint_coord_index = coords_offset_j + coord
         actuator_coord_index = actuated_coords_offset_j + coord
-        data_joint_q_j_ref[joint_coord_index] = animation_q_j_ref[frame, actuator_coord_index]
+        control_q_j_ref[joint_coord_index] = animation_q_j_ref[frame, actuator_coord_index]
     for dof in range(num_dofs_j):
         joint_dof_index = dofs_offset_j + dof
         actuator_dof_index = actuated_dofs_offset_j + dof
-        data_joint_dq_j_ref[joint_dof_index] = animation_dq_j_ref[frame, actuator_dof_index]
+        control_dq_j_ref[joint_dof_index] = animation_dq_j_ref[frame, actuator_dof_index]
+        control_tau_j_ref[joint_coord_index] = 0.0  # No feed-forward term in this example
 
 
 ###
@@ -160,8 +162,9 @@ def pd_control_callback(sim: Simulator, animation: AnimationJointReference, deci
             animation.data.q_j_ref,
             animation.data.dq_j_ref,
             # Outputs:
-            sim.solver.data.joints.q_j_ref,
-            sim.solver.data.joints.dq_j_ref,
+            sim.control.q_j_ref,
+            sim.control.dq_j_ref,
+            sim.control.tau_j_ref,
         ],
     )
 

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -737,6 +737,9 @@ class SolverKamino(SolverBase):
         wp.copy(self._data.joints.dq_j, state_in.dq_j)
         wp.copy(self._data.joints.lambda_j, state_in.lambda_j)
         wp.copy(self._data.joints.tau_j, control_in.tau_j)
+        wp.copy(self._data.joints.q_j_ref, control_in.q_j_ref)
+        wp.copy(self._data.joints.dq_j_ref, control_in.dq_j_ref)
+        wp.copy(self._data.joints.tau_j_ref, control_in.tau_j_ref)
 
     def _write_step_output(self, state_out: State):
         """


### PR DESCRIPTION
## Description
This super lightweight PR simply adds a final modification to the user-facing interfaces so that implicit and explicit control inputs are exposed to the front-end and propagated correctly.

## Notes
Currently there are many memory copies from State and Control into the ModelData. This will be revised in the future to capture references instead and avoid the extra memory allocations and copies.

## Before your PR is "Ready for review"
- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
