### PR TITLE
Move sparse Delassus op update handling into operator

### DIFF
--- a/newton/_src/solvers/kamino/dynamics/dual.py
+++ b/newton/_src/solvers/kamino/dynamics/dual.py
@@ -1428,7 +1428,7 @@ class DualProblem:
         self._data.mu.zero_()
         self._data.P.fill_(1.0)
         if self._sparse:
-            self._delassus.update()
+            self._delassus.set_needs_update()
 
     def build(
         self,
@@ -1518,9 +1518,6 @@ class DualProblem:
         if any(s.preconditioning for s in self._settings):
             self._build_dual_preconditioner()
             self._apply_dual_preconditioner_to_dual()
-
-        if self._sparse:
-            self._delassus.update()
 
     ###
     # Internals

--- a/newton/_src/solvers/kamino/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/solvers/metrics.py
@@ -1491,7 +1491,6 @@ class SolutionMetrics:
             delassus_pre_prev = problem.delassus._preconditioner
             problem.delassus.set_regularization(None)
             problem.delassus.set_preconditioner(None)
-            problem.delassus.update()
             problem.delassus.matvec(
                 x=lambdas,
                 y=self._buffer_v,
@@ -1499,7 +1498,6 @@ class SolutionMetrics:
             )
             problem.delassus.set_regularization(delassus_reg_prev)
             problem.delassus.set_preconditioner(delassus_pre_prev)
-            problem.delassus.update()
             wp.launch(
                 kernel=_compute_dual_problem_metrics_sparse,
                 dim=problem.size.num_worlds,

--- a/newton/_src/solvers/kamino/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/solvers/padmm/solver.py
@@ -466,6 +466,7 @@ class PADMMSolver:
                 problem.delassus._eta,
             ],
         )
+        problem.delassus.set_needs_update()
 
     def _update_regularization(self, problem: DualProblem):
         """


### PR DESCRIPTION
## Description

This modifies how updates to the sparse Delassus operator are handled. Instead of users of the operator having to call `update()` on changes to the operator, they signal to the operator that there was a change, and then the operator performs the update at the point where it is necessary.

This avoids redundant update calls and simplifies the handling of the class a bit.

Specifically, this fixes an issue where an update to the regularization was not applied in the current step, but only the next step of a simulation.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
