### PR TITLE
Fix geometry hash bottleneck upon finalizing the builder

### DIFF
--- a/newton/_src/solvers/kamino/core/builder.py
+++ b/newton/_src/solvers/kamino/core/builder.py
@@ -1233,13 +1233,13 @@ class ModelBuilder:
         def make_geometry_source_pointer(geom: GeometryDescriptor, mesh_geoms: dict, device) -> int:
             # Append to data pointers array of the shape has a Mesh, SDF or HField source
             if geom.shape.type in (ShapeType.MESH, ShapeType.CONVEX, ShapeType.HFIELD, ShapeType.SDF):
-                geom_hash = hash(geom)  # avoid repeated hash computations
+                geom_uid = geom.uid
                 # If the geometry has a Mesh, SDF or HField source,
                 # finalize it and retrieve the mesh pointer/index
-                if geom_hash not in mesh_geoms:
-                    mesh_geoms[geom_hash] = geom.shape.data.finalize(device=device)
+                if geom_uid not in mesh_geoms:
+                    mesh_geoms[geom_uid] = geom.shape.data.finalize(device=device)
                 # Return the mesh data pointer/index
-                return mesh_geoms[geom_hash]
+                return mesh_geoms[geom_uid]
             # Otherwise, append a null (i.e. zero-valued) pointer
             else:
                 return 0


### PR DESCRIPTION
This replaces the geometry hash computation (used to avoid loading the same geometry twice on the GPU) with using the already existing geometry unique ids (loaded from USD or generated automatically) for the same purpose, which drastically cuts down the finalize() time for models with meshes and many worlds.

This was validated on the DR legs sim example with 1024 worlds, checking that the finalize() time is quick and the same number of geoms are loaded to the GPU as with 1 world.