### PR TITLE
Fix device assignment in sparse CG test on CPU

### DIFF
--- a/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
+++ b/newton/_src/solvers/kamino/tests/test_linalg_solve_cg.py
@@ -462,7 +462,9 @@ class TestLinalgConjugate(unittest.TestCase):
         x_wp = wp.zeros(n_worlds * maxdim, dtype=float32, device=device)
 
         # Solve with discover_sparse=True
-        solver = ConjugateGradientSolver(discover_sparse=True, sparse_block_size=block_size, sparse_threshold=1.0)
+        solver = ConjugateGradientSolver(
+            discover_sparse=True, sparse_block_size=block_size, sparse_threshold=1.0, device=device
+        )
         solver.finalize(dense_op)
         solver.compute(A_wp)
         solver.solve(b_wp, x_wp)
@@ -481,7 +483,7 @@ class TestLinalgConjugate(unittest.TestCase):
 
         # Also solve with discover_sparse=False and compare
         x_dense_wp = wp.zeros(n_worlds * maxdim, dtype=float32, device=device)
-        solver_dense = ConjugateGradientSolver(discover_sparse=False)
+        solver_dense = ConjugateGradientSolver(discover_sparse=False, device=device)
         solver_dense.finalize(dense_op)
         solver_dense.compute(A_wp)
         solver_dense.solve(b_wp, x_dense_wp)


### PR DESCRIPTION
## Description

This fixes a test failure that appeared when running the CG/CR tests with the device set to `cpu` on a platform that also has a CUDA-capable GPU.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
