### PR TITLE
Fix computation of kinematics residual with sparse Jacobian

### DIFF
--- a/newton/_src/solvers/kamino/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/solvers/metrics.py
@@ -1452,7 +1452,7 @@ class SolutionMetrics:
                         model.joints.bid_F,
                         data.bodies.u_i,
                         J_cts.nzb_values,
-                        jacobians._J_dofs_joint_nzb_offsets,
+                        jacobians._J_cts_joint_nzb_offsets,
                         # Outputs:
                         self._data.r_kinematics,
                         self._data.r_kinematics_argmax,


### PR DESCRIPTION
This fixes the computation of the kinematic constraints residual (max of constraint Jacobian times velocity) in the solver metrics, when the sparse Jacobian is used. The issue was that the per-joint NZB offsets corresponding to the dofs Jacobian, rather than the cts Jacobian, were provided to the kernel doing this computation.