### PR TITLE
Fix import of rich console

### DIFF
--- a/newton/_src/solvers/kamino/utils/benchmark/render.py
+++ b/newton/_src/solvers/kamino/utils/benchmark/render.py
@@ -75,7 +75,7 @@ def _render_table_to_console_and_file(
     # Attempt to import rich first, and warn user
     # if the necessary package is not installed
     try:
-        from rich.text import Console  # noqa: PLC0415
+        from rich.console import Console  # noqa: PLC0415
     except ImportError as e:
         raise ImportError(
             "The `rich` package is required for rendering tables. Install it with: pip install rich"


### PR DESCRIPTION
## Description

This PR fixes an issue with one of the imports of `rich` using the wrong namespace to import `Console`.

## Before your PR is "Ready for review"

- [x] Necessary tests have been added and new examples are tested (see `newton/tests/test_examples.py`)
- [x] Documentation is up-to-date
- [x] Code passes formatting and linting checks with `pre-commit run -a`
