### PR TITLE
Disable FK solver by default to save memory

### DIFF
--- a/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
@@ -159,6 +159,7 @@ class Example:
         config.solver.contact_warmstart_method = "geom_pair_net_force"
         config.solver.collect_solver_info = False
         config.solver.compute_metrics = False
+        config.solver.use_fk_solver = True
 
         # Create a simulator
         msg.notif("Building the simulator...")

--- a/newton/_src/solvers/kamino/solver_kamino.py
+++ b/newton/_src/solvers/kamino/solver_kamino.py
@@ -255,7 +255,9 @@ class SolverKaminoImpl(SolverBase):
         )
 
         # Allocate the forward kinematics solver on the device
-        self._solver_fk = ForwardKinematicsSolver(model=self._model, config=self._config.fk)
+        self._solver_fk = None
+        if self._config.use_fk_solver:
+            self._solver_fk = ForwardKinematicsSolver(model=self._model, config=self._config.fk)
 
         # Create the time-integrator instance based on the config
         if self._config.integrator == "euler":
@@ -342,9 +344,9 @@ class SolverKaminoImpl(SolverBase):
         return self._solver_fd
 
     @property
-    def solver_fk(self) -> ForwardKinematicsSolver:
+    def solver_fk(self) -> ForwardKinematicsSolver | None:
         """
-        Returns the forward kinematics solver backend.
+        Returns the forward kinematics solver backend, if it was initialized.
         """
         return self._solver_fk
 
@@ -817,6 +819,10 @@ class SolverKaminoImpl(SolverBase):
         Resets the simulation to the given joint states by solving
         the forward kinematics to compute the corresponding body states.
         """
+        # Check that the FK solver was initialized
+        if self._solver_fk is None:
+            raise RuntimeError("The FK solver must be enabled to use resets from joint angles.")
+
         # Detect if joint or actuator targets are provided
         with_joint_targets = joint_q is not None and (actuator_q is None and actuator_u is None)
 
@@ -1239,6 +1245,11 @@ class SolverKamino(SolverBase):
         sparse_jacobian: bool = False
         """
         Flag to indicate whether the solver should use sparse data representations for the Jacobian.
+        """
+
+        use_fk_solver: bool = False
+        """
+        Flag to indicate that the FK solver, allowing for resets using joint angles, should be enabled.
         """
 
         def check(self) -> None:

--- a/newton/_src/solvers/kamino/utils/benchmark/__main__.py
+++ b/newton/_src/solvers/kamino/utils/benchmark/__main__.py
@@ -328,6 +328,7 @@ def benchmark_run(args: argparse.Namespace):
             # Construct simulator configurations based on the solver
             # configurations for the current benchmark configuration
             sim_configs = Simulator.Config(dt=args.dt, solver=configs)
+            sim_configs.solver.use_fk_solver = False
 
             # Execute the benchmark for the current problem and settings
             run_single_benchmark(


### PR DESCRIPTION
This adds a flag to enable/disable the FK solver, and disables it by default to avoid the associated memory consumption (especially as the usage of that solver in a RL context is still not fully clear)