### PR TITLE
Fix overflow issue

### DIFF
--- a/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked.py
+++ b/newton/_src/solvers/kamino/_src/linalg/factorize/llt_blocked.py
@@ -61,7 +61,7 @@ def make_get_array_offset_ptr_func(dtype):
     # Define a Warp function to get the raw pointer of a warp array with an offset
     @wp.func
     def get_dtype_array_offset_ptr(arr: wp.array(dtype=dtype), start_index: int) -> wp.uint64:
-        return get_dtype_array_ptr(arr) + wp.uint64(start_index * wp.static(sizeof(dtype._type_)))
+        return get_dtype_array_ptr(arr) + wp.uint64(start_index) * wp.uint64(wp.static(sizeof(dtype._type_)))
 
     return get_dtype_array_offset_ptr
 


### PR DESCRIPTION
This fixes an issue preventing to run the dense LLT solver with too many worlds, due to an interger overflow resulting in a CUDA 700. All the credit for this fix goes to @aserifi 