### PR TITLE
Fix rich console output on Windows and progress bar blinking

### DIFF
--- a/newton/_src/solvers/kamino/_src/utils/logger.py
+++ b/newton/_src/solvers/kamino/_src/utils/logger.py
@@ -18,8 +18,22 @@ KAMINO: Utilities: Message Logging
 """
 
 import logging
+import sys
 from enum import IntEnum
 from typing import ClassVar
+
+# Fix rich console output on Windows
+if sys.platform == "win32":
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+
+    mode = ctypes.c_uint()
+    kernel32.GetConsoleMode(handle, ctypes.byref(mode))
+
+    mode.value |= 0x0004  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    kernel32.SetConsoleMode(handle, mode)
 
 
 class LogLevel(IntEnum):

--- a/newton/_src/solvers/kamino/examples/__init__.py
+++ b/newton/_src/solvers/kamino/examples/__init__.py
@@ -80,8 +80,9 @@ def print_progress_bar(iteration, total, start_time, length=40, prefix="", suffi
         eta_str = "Calculating..."
         fps_str = "-- fps"
 
-    line_reset = " " * 120
-    sys.stdout.write(f"\r{line_reset}")
+    if sys.platform != "win32":
+        line_reset = " " * 120
+        sys.stdout.write(f"\r{line_reset}")
     sys.stdout.write(f"\r{prefix} |{bar}| {iteration}/{total} ETA: {eta_str} ({fps_str}) {suffix}")
     sys.stdout.flush()
 


### PR DESCRIPTION
This fixes the rich console output on Windows (colors etc), which don't display in the built-in console by default unless it is enabled. Let me know if it is ok to put this in the __init__.py