### PR TITLE
Remove deferred assignment of jacobian in sparse Delassus operator

### DIFF
--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -1191,7 +1191,7 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         be active in each world.
 
         Args:
-            model (ModelKamino):
+            model (ModelKamino, optional):
                 The model container for which the Delassus operator is built.
             data (DataKamino, optional):
                 The model data container holding the state info and data.
@@ -1201,7 +1201,6 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
                 Contacts data container for contact constraints.
             jacobians (SparseSystemJacobians, optional):
                 The sparse Jacobians container.
-                Can be assigned later via the `assign` method.
             solver (LinearSolverType, optional):
                 The linear solver class to use for solving linear systems.
                 Must be a subclass of `IterativeSolver`.
@@ -1261,9 +1260,9 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         self,
         model: ModelKamino,
         data: DataKamino,
+        jacobians: SparseSystemJacobians,
         limits: LimitsKamino | None,
         contacts: ContactsKamino | None,
-        jacobians: SparseSystemJacobians | None = None,
         solver: LinearSolverType = None,
         device: wp.DeviceLike = None,
         solver_kwargs: dict[str, Any] | None = None,
@@ -1276,13 +1275,12 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
                 The model container for which the Delassus operator is built.
             data (DataKamino):
                 The model data container holding the state info and data.
+            jacobians (SparseSystemJacobians):
+                The sparse Jacobians container.
             limits (LimitsKamino, optional):
                 Limits data container for joint limit constraints.
             contacts (ContactsKamino, optional):
                 Contacts data container for contact constraints.
-            jacobians (SparseSystemJacobians, optional):
-                The sparse Jacobians container.
-                Can be assigned later via the `assign` method.
             solver (LinearSolverType, optional):
                 The linear solver class to use for solving linear systems.
                 Must be a subclass of `IterativeSolver`.
@@ -1307,6 +1305,10 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
             )
         elif not isinstance(data, DataKamino):
             raise ValueError("Invalid data container provided. Must be an instance of `DataKamino`.")
+
+        # Ensure the Jacobians are provided
+        if jacobians is None:
+            raise ValueError("The sparse system Jacobians must be provided to allocate the Delassus operator.")
 
         # Ensure the solver is iterative if provided
         if solver is not None and not issubclass(solver, IterativeSolver):
@@ -1379,34 +1381,12 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
         else:
             self._col_major_jacobian = None
 
-        # Assign Jacobian if specified
-        if jacobians is not None:
-            self.assign(jacobians)
-
-        # Optionally initialize the iterative linear system solver if one is specified
-        if solver is not None:
-            solver_kwargs = solver_kwargs or {}
-            self._solver = solver(operator=self, device=self._device, **solver_kwargs)
-
-        self.set_needs_update()
-
-    def assign(self, jacobians: SparseSystemJacobians):
-        """
-        Assigns the constraint Jacobian to the Delassus operator.
-
-        This method links the Delassus operator to the block sparse Jacobian matrix,
-        which is used to compute the implicit Delassus matrix-vector products.
-
-        Args:
-            jacobians (SparseSystemJacobians):
-                The sparse system Jacobians container holding the
-                constraint Jacobian matrix in block sparse format.
-        """
+        # Assign Jacobian
         self._jacobians = jacobians
 
+        # Create copy of constraint Jacobian with separate non-zero block values, so we can apply
+        # preconditioning directly to the Jacobian.
         if self._col_major_jacobian is None and self._transpose_op_matrix is None:
-            # Create copy of constraint Jacobian with separate non-zero block values, so we can apply
-            # preconditioning directly to the Jacobian.
             self._transpose_op_matrix = copy.copy(jacobians._J_cts.bsm)
             self._transpose_op_matrix.nzb_values = wp.empty_like(self.constraint_jacobian.nzb_values)
 
@@ -1417,7 +1397,12 @@ class BlockSparseMatrixFreeDelassusOperator(BlockSparseLinearOperators):
             self.bsm = copy.copy(jacobians._J_cts.bsm)
             self.bsm.nzb_values = wp.empty_like(self.constraint_jacobian.nzb_values)
 
-        self.update()
+        # Optionally initialize the iterative linear system solver if one is specified
+        if solver is not None:
+            solver_kwargs = solver_kwargs or {}
+            self._solver = solver(operator=self, device=self._device, **solver_kwargs)
+
+        self.set_needs_update()
 
     def set_needs_update(self):
         """

--- a/newton/_src/solvers/kamino/_src/dynamics/dual.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/dual.py
@@ -1092,6 +1092,7 @@ class DualProblem:
         data: DataKamino | None = None,
         limits: LimitsKamino | None = None,
         contacts: ContactsKamino | None = None,
+        jacobians: SparseSystemJacobians | DenseSystemJacobians | None = None,
         solver: LinearSolverType | None = None,
         solver_kwargs: dict[str, Any] | None = None,
         config: list[DualProblem.Config] | DualProblem.Config | None = None,
@@ -1114,6 +1115,8 @@ class DualProblem:
                 The model to build the dual problem for.
             contacts (ContactsKamino, optional):
                 The contacts container to use for the dual problem.
+            jacobians (SparseSystemJacobians | DenseSystemJacobians, optional):
+                The constraints Jacobians for this model. Must be provided if model is provided.
             solver (LinearSolverType, optional):
                 The linear solver to use for the Delassus operator. Defaults to None.
             config (List[DualProblem.Config] | DualProblem.Config, optional):
@@ -1153,6 +1156,7 @@ class DualProblem:
                 data=data,
                 limits=limits,
                 contacts=contacts,
+                jacobians=jacobians,
                 solver=solver,
                 solver_kwargs=solver_kwargs,
                 config=config,
@@ -1226,6 +1230,7 @@ class DualProblem:
     def finalize(
         self,
         model: ModelKamino,
+        jacobians: SparseSystemJacobians | DenseSystemJacobians,
         data: DataKamino | None = None,
         limits: LimitsKamino | None = None,
         contacts: ContactsKamino | None = None,
@@ -1240,8 +1245,10 @@ class DualProblem:
         for the given model, limits, contacts and Jacobians.
 
         Args:
-            model (ModelKamino, optional):
+            model (ModelKamino):
                 The model to build the dual problem for.
+            jacobians (SparseSystemJacobians | DenseSystemJacobians):
+                The constraints Jacobians for this model.
             contacts (ContactsKamino, optional):
                 The contacts container to use for the dual problem.
             solver (LinearSolverType, optional):
@@ -1298,6 +1305,7 @@ class DualProblem:
                 data=data,
                 limits=limits,
                 contacts=contacts,
+                jacobians=jacobians,
                 solver=solver,
                 solver_kwargs=solver_kwargs,
                 device=device,
@@ -1417,11 +1425,9 @@ class DualProblem:
         if reset_to_zero:
             self.zero()
 
-        # Build the Delassus operator
+        # Build the dense Delassus operator if applicable
         # NOTE: We build this first since it will update the arrays of active constraints
-        if self._sparse:
-            self._delassus.assign(jacobians=jacobians)
-        else:
+        if not self._sparse:
             self._delassus.build(
                 model=model,
                 data=data,

--- a/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
+++ b/newton/_src/solvers/kamino/_src/solver_kamino_impl.py
@@ -234,6 +234,7 @@ class SolverKaminoImpl(SolverBase):
             data=self._data,
             limits=self._limits,
             contacts=contacts,
+            jacobians=self._jacobians,
             config=problem_fd_config,
             solver=linear_solver_type,
             solver_kwargs=linear_solver_kwargs,

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -55,7 +55,7 @@ A typical example for using this module is:
     ...
 
     # Create a forward-dynamics DualProblem to be solved
-    dual = DualProblem(model, limits, contacts)
+    dual = DualProblem(model, limits, contacts, jacobians)
     dual.build(model, data, limits, contacts, jacobians)
 
     # Create a forward-dynamics PADMM solver

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/__init__.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/__init__.py
@@ -69,7 +69,7 @@ A typical example for using this module is:
     ...
 
     # Create a forward-dynamics DualProblem to be solved
-    dual = DualProblem(model, limits, contacts)
+    dual = DualProblem(model, limits, contacts, jacobians)
     dual.build(model, data, limits, contacts, jacobians)
 
     # Create a forward-dynamics PADMM solver

--- a/newton/_src/solvers/kamino/tests/test_dynamics_delassus.py
+++ b/newton/_src/solvers/kamino/tests/test_dynamics_delassus.py
@@ -1186,6 +1186,7 @@ class TestDelassusOperatorSparse(unittest.TestCase):
             data=data,
             limits=limits,
             contacts=detector.contacts,
+            jacobians=jacobians,
             device=self.default_device,
         )
 
@@ -1214,6 +1215,7 @@ class TestDelassusOperatorSparse(unittest.TestCase):
             data=data,
             limits=limits,
             contacts=detector.contacts,
+            jacobians=jacobians,
             device=self.default_device,
         )
 
@@ -1241,6 +1243,7 @@ class TestDelassusOperatorSparse(unittest.TestCase):
             data=data,
             limits=limits,
             contacts=detector.contacts,
+            jacobians=jacobians,
             device=self.default_device,
         )
 

--- a/newton/_src/solvers/kamino/tests/test_dynamics_dual.py
+++ b/newton/_src/solvers/kamino/tests/test_dynamics_dual.py
@@ -56,7 +56,7 @@ class TestDualProblem(unittest.TestCase):
         builder = make_basics_heterogeneous_builder()
 
         # Create the model and containers from the builder
-        model, data, _state, limits, detector, _jacobians = make_containers(
+        model, data, _state, limits, detector, jacobians = make_containers(
             builder=builder, max_world_contacts=max_world_contacts, device=self.default_device
         )
 
@@ -66,6 +66,7 @@ class TestDualProblem(unittest.TestCase):
             data=data,
             limits=limits,
             contacts=detector.contacts,
+            jacobians=jacobians,
             solver=ConjugateGradientSolver,
             device=self.default_device,
         )
@@ -136,6 +137,7 @@ class TestDualProblem(unittest.TestCase):
             data=data,
             limits=limits,
             contacts=detector.contacts,
+            jacobians=jacobians,
             solver=ConjugateGradientSolver,
             device=self.default_device,
         )

--- a/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_metrics.py
@@ -707,6 +707,7 @@ class TestSolverMetrics(unittest.TestCase):
             data=test.data,
             limits=test.limits,
             contacts=test.contacts,
+            jacobians=jacobians_sparse,
             device=self.default_device,
             sparse=True,
         )

--- a/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
+++ b/newton/_src/solvers/kamino/tests/test_solvers_padmm.py
@@ -81,6 +81,7 @@ class TestSetup:
             data=self.data,
             limits=self.limits,
             contacts=self.contacts,
+            jacobians=self.jacobians,
             solver=ConjugateResidualSolver if sparse else LLTBlockedSolver,
             device=device,
             sparse=sparse,


### PR DESCRIPTION
The recent CG/CR solver PR introduced an issue, breaking unit tests and examples (when using the sparse solvers). Indeed, initializing the CG/CR solver (more specifically, creating the BatchedLinearOperator with from_block_sparse_operator()) now requires the sparse matrix to have been finalized (in particular, row starts are required).

Therefore, the logic of the sparse Delassus operator, finalizing the linear solver before assigning the Jacobian, is no longer possible. The Jacobian has now been made required to finalize the sparse Delassus operator (removing the assign() method), and this requirement was propagated up to the dual problem. This fixes the unit tests and examples.