### PR TITLE
Run graph capture after simulator warm-up

### DIFF
--- a/newton/_src/solvers/kamino/_src/utils/benchmark/runner.py
+++ b/newton/_src/solvers/kamino/_src/utils/benchmark/runner.py
@@ -106,14 +106,14 @@ class BenchmarkSim:
         self.reset_graph = None
         self.step_graph = None
 
-        # Capture CUDA graph if requested and available
-        self._capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.info("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self._capture()
 
     ###
     # Operations

--- a/newton/_src/solvers/kamino/_src/utils/sim/runner.py
+++ b/newton/_src/solvers/kamino/_src/utils/sim/runner.py
@@ -86,14 +86,14 @@ class SimulationRunner:
         self.reset_graph = None
         self.step_graph = None
 
-        # Capture CUDA graph if requested and available
-        self._capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulation...")
         self.step()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self._capture()
 
     ###
     # Simulation API

--- a/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/reset/example_reset_dr_legs.py
@@ -231,14 +231,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/rl/simulation.py
+++ b/newton/_src/solvers/kamino/examples/rl/simulation.py
@@ -303,15 +303,17 @@ class RigidBodySim:
             self._newton_state = self._newton_model.state()
             self._apply_render_config(self._render_config)
 
-        # ----- CUDA graphs -----
+        # ----- Initialize empty CUDA graphs -----
         self._reset_graph = None
         self._step_graph = None
-        self._capture_graphs()
 
         # ----- Warm-up (compiles Warp kernels) -----
         msg.notif("Warming up simulator ...")
         self.step()
         self.reset()
+
+        # ----- Capture CUDA graphs -----
+        self._capture_graphs()
 
     # ------------------------------------------------------------------
     # Viewer appearance

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_all_heterogeneous.py
@@ -170,14 +170,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_on_plane.py
@@ -208,14 +208,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_box_pendulum.py
@@ -158,14 +158,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_fourbar.py
@@ -302,14 +302,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_boxes_hinged.py
@@ -194,14 +194,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_basics_cartpole.py
@@ -236,14 +236,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def make_rl_interface(self):
         """

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_legs.py
@@ -371,14 +371,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_dr_testmech.py
@@ -124,14 +124,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_geoms.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_geoms.py
@@ -152,14 +152,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""

--- a/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
+++ b/newton/_src/solvers/kamino/examples/sim/example_sim_test_all_joints.py
@@ -120,14 +120,14 @@ class Example:
         self.step_graph = None
         self.simulate_graph = None
 
-        # Capture CUDA graph if requested and available
-        self.capture()
-
         # Warm-start the simulator before rendering
         # NOTE: This compiles and loads the warp kernels prior to execution
         msg.notif("Warming up simulator...")
         self.step_once()
         self.reset()
+
+        # Capture CUDA graph if requested and available
+        self.capture()
 
     def capture(self):
         """Capture CUDA graph if requested and available."""


### PR DESCRIPTION
This fixes #320 (in the best possible way for now), by changing the order of graph capture and simulator warm-up, thus ensuring that kernels are compiled and any necessary allocation needed under the hood is performed, before capturing.

The warp issue https://github.com/NVIDIA/warp/issues/1373 will address this in a more permanent way by fixing these under-the-hood allocations (and we will get the fix by upgrading warp).