### PR TITLE
fix CPU race in fused Nesterov update

### DIFF
--- a/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
@@ -857,9 +857,7 @@ def _compute_projection_argument_and_project(
     ccgo = problem_ccgo[wid]
 
     # Check if this constraint index falls within the limit range
-    limit_start = lcgo
-    limit_end = lcgo + nl
-    if nl > 0 and tid >= limit_start and tid < limit_end:
+    if nl > 0 and tid >= lcgo and tid < lcgo + nl:
         solver_y[thread_offset] = wp.max(y_val, 0.0)
 
     # Check if this constraint index falls within a contact block
@@ -1346,6 +1344,7 @@ def _make_compute_infnorm_residuals_accel_kernel(tile_size: int, n_cts_max: int,
         # Outputs:
         solver_state_done: wp.array(dtype=int32),
         solver_state_a: wp.array(dtype=float32),
+        solver_state_a_factor: wp.array(dtype=float32),
         solver_status: wp.array(dtype=PADMMStatus),
         solver_penalty: wp.array(dtype=PADMMPenalty),
         linear_solver_atol: wp.array(dtype=float32),
@@ -1511,12 +1510,15 @@ def _make_compute_infnorm_residuals_accel_kernel(tile_size: int, n_cts_max: int,
             if status.r_a < config.restart_tolerance * status.r_a_p:
                 status.restart = 0
                 a_p = solver_state_a_p[wid]
-                solver_state_a[wid] = (1.0 + wp.sqrt(1.0 + 4.0 * a_p * a_p)) / 2.0
+                a = (1.0 + wp.sqrt(1.0 + 4.0 * a_p * a_p)) / 2.0
+                solver_state_a[wid] = a
+                solver_state_a_factor[wid] = (a_p - 1.0) / a
             else:
                 status.restart = 1
                 status.num_restarts += 1
                 status.r_a = status.r_a_p / config.restart_tolerance
                 solver_state_a[wid] = float(config.a_0)
+                solver_state_a_factor[wid] = float32(0.0)
             status.r_a_pp = status.r_a_p
             status.r_a_p = status.r_a
 
@@ -1597,10 +1599,10 @@ def _update_acceleration_and_cache_previous(
     problem_vio: wp.array(dtype=int32),
     solver_status: wp.array(dtype=PADMMStatus),
     solver_state_a: wp.array(dtype=float32),
+    solver_state_a_factor: wp.array(dtype=float32),
     solver_state_x: wp.array(dtype=float32),
     solver_state_y: wp.array(dtype=float32),
     solver_state_z: wp.array(dtype=float32),
-    solver_state_a_p: wp.array(dtype=float32),
     solver_state_y_p: wp.array(dtype=float32),
     solver_state_z_p: wp.array(dtype=float32),
     # Outputs:
@@ -1611,47 +1613,37 @@ def _update_acceleration_and_cache_previous(
     solver_state_z_p_out: wp.array(dtype=float32),
     solver_state_a_p_out: wp.array(dtype=float32),
 ):
-    """Fused kernel: Nesterov acceleration update + cache previous state.
-
-    Combines _update_state_with_acceleration and wp.copy(x to x_p, y to y_p, z to z_p, a to a_p)
-    into a single kernel to reduce kernel launch overhead.
-    """
+    """Fused kernel: Nesterov acceleration update + cache previous state."""
     wid, tid = wp.tid()
 
     ncts = problem_dim[wid]
     status = solver_status[wid]
 
-    if tid >= ncts or status.converged > 0:
+    if tid >= ncts:
         return
 
     vio = problem_vio[wid]
     vid = vio + tid
 
-    # Read current state and old previous state
     x = solver_state_x[vid]
     y = solver_state_y[vid]
     z = solver_state_z[vid]
     y_p = solver_state_y_p[vid]
     z_p = solver_state_z_p[vid]
 
-    # Cache current → previous
+    if status.converged == 0:
+        if status.restart == 0:
+            factor = solver_state_a_factor[wid]
+            solver_state_y_hat[vid] = y + factor * (y - y_p)
+            solver_state_z_hat[vid] = z + factor * (z - z_p)
+        else:
+            solver_state_y_hat[vid] = y_p
+            solver_state_z_hat[vid] = z_p
+
     solver_state_x_p_out[vid] = x
     solver_state_y_p_out[vid] = y
     solver_state_z_p_out[vid] = z
 
-    # Nesterov acceleration update using saved old values
-    if status.restart == 0:
-        a = solver_state_a[wid]
-        a_p = solver_state_a_p[wid]
-
-        factor = (a_p - 1.0) / a
-        solver_state_y_hat[vid] = y + factor * (y - y_p)
-        solver_state_z_hat[vid] = z + factor * (z - z_p)
-    else:
-        solver_state_y_hat[vid] = y_p
-        solver_state_z_hat[vid] = z_p
-
-    # Cache acceleration parameter (only first thread per world)
     if tid == 0:
         solver_state_a_p_out[wid] = solver_state_a[wid]
 

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/kernels.py
@@ -1614,23 +1614,31 @@ def _update_acceleration_and_cache_previous(
     solver_state_a_p_out: wp.array(dtype=float32),
 ):
     """Fused kernel: Nesterov acceleration update + cache previous state."""
+    # Retrieve the thread indices as the world and constraint index
     wid, tid = wp.tid()
 
+    # Retrieve the total number of active constraints
+    # in the world and the current solver status
     ncts = problem_dim[wid]
     status = solver_status[wid]
 
+    # Skip if row index exceed the problem size
     if tid >= ncts:
         return
 
+    # Retrieve the index offset of the vector block of the world
     vio = problem_vio[wid]
     vid = vio + tid
 
+    # Read current state and old previous state
     x = solver_state_x[vid]
     y = solver_state_y[vid]
     z = solver_state_z[vid]
     y_p = solver_state_y_p[vid]
     z_p = solver_state_z_p[vid]
 
+    # Update the auxiliary primal-dual state with Nesterov acceleration
+    # if not restarting, else reset to the previous slack and dual state
     if status.converged == 0:
         if status.restart == 0:
             factor = solver_state_a_factor[wid]
@@ -1640,10 +1648,12 @@ def _update_acceleration_and_cache_previous(
             solver_state_y_hat[vid] = y_p
             solver_state_z_hat[vid] = z_p
 
+    # Cache current → previous state for the next iteration
     solver_state_x_p_out[vid] = x
     solver_state_y_p_out[vid] = y
     solver_state_z_p_out[vid] = z
 
+    # Only one thread needs to cache the scalar acceleration parameter
     if tid == 0:
         solver_state_a_p_out[wid] = solver_state_a[wid]
 

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/solver.py
@@ -1252,6 +1252,7 @@ class PADMMSolver:
                 # Outputs:
                 self._data.state.done,
                 self._data.state.a,
+                self._data.state.a_factor,
                 self._data.status,
                 self._data.penalty,
                 self._data.linear_solver_atol,
@@ -1453,10 +1454,7 @@ class PADMMSolver:
         self._update_previous_state()
 
     def _update_acceleration_and_cache_previous(self, problem: DualProblem):
-        """Fused kernel: Nesterov acceleration update + cache previous state variables.
-
-        Replaces _update_acceleration + _update_previous_state_accel with a single kernel launch.
-        """
+        """Fused kernel: Nesterov acceleration update + cache previous state variables."""
         wp.launch(
             kernel=_update_acceleration_and_cache_previous,
             dim=(self._size.num_worlds, self._size.max_of_max_total_cts),
@@ -1466,10 +1464,10 @@ class PADMMSolver:
                 problem.data.vio,
                 self._data.status,
                 self._data.state.a,
+                self._data.state.a_factor,
                 self._data.state.x,
                 self._data.state.y,
                 self._data.state.z,
-                self._data.state.a_p,
                 self._data.state.y_p,
                 self._data.state.z_p,
                 # Outputs:

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
@@ -519,6 +519,8 @@ class PADMMState:
             Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
         a_p (wp.array): The previous PADMM acceleration variables.\n
             Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
+        a_factor (wp.array): The per-world Nesterov factor computed from the previous and current acceleration
+            variables. Shape of ``(num_worlds,)`` and type :class:`float32`.
     """
 
     def __init__(self, size: SizeKamino | None = None, use_acceleration: bool = False):
@@ -630,6 +632,13 @@ class PADMMState:
         Shape of ``(num_worlds,)`` and type :class:`float32`.
         """
 
+        self.a_factor: wp.array | None = None
+        """
+        The per-world Nesterov acceleration factor.\n
+        Only allocated if acceleration is enabled.\n
+        Shape of ``(num_worlds,)`` and type :class:`float32`.
+        """
+
         # Perform memory allocations if model size is specified
         if size is not None:
             self.finalize(size, use_acceleration)
@@ -661,6 +670,7 @@ class PADMMState:
             self.z_hat = wp.zeros(size.sum_of_max_total_cts, dtype=float32)
             self.a = wp.zeros(size.num_worlds, dtype=float32)
             self.a_p = wp.zeros(size.num_worlds, dtype=float32)
+            self.a_factor = wp.zeros(size.num_worlds, dtype=float32)
 
     def reset(self, use_acceleration: bool = False):
         """
@@ -696,6 +706,7 @@ class PADMMState:
             # Reset acceleration scale variables
             self.a.fill_(1.0)
             self.a_p.fill_(1.0)
+            self.a_factor.zero_()
 
 
 class PADMMResiduals:

--- a/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
+++ b/newton/_src/solvers/kamino/_src/solvers/padmm/types.py
@@ -515,9 +515,9 @@ class PADMMState:
             Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
         z_hat (wp.array): The auxiliary PADMM dual variables used with gradient acceleration.\n
             Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        a (wp.array): The current PADMM acceleration variables.\n
+        a (wp.array): The per-world current Nesterov acceleration variables.\n
             Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
-        a_p (wp.array): The previous PADMM acceleration variables.\n
+        a_p (wp.array): The per-world previous Nesterov acceleration variables.\n
             Shape of ``(sum_of_max_total_cts,)`` and type :class:`float32`.
         a_factor (wp.array): The per-world Nesterov factor computed from the previous and current acceleration
             variables. Shape of ``(num_worlds,)`` and type :class:`float32`.
@@ -620,21 +620,21 @@ class PADMMState:
 
         self.a: wp.array | None = None
         """
-        The current PADMM acceleration variables.\n
+        The per-world current Nesterov acceleration variables.\n
         Only allocated if acceleration is enabled.\n
         Shape of ``(num_worlds,)`` and type :class:`float32`.
         """
 
         self.a_p: wp.array | None = None
         """
-        The previous PADMM acceleration variables.\n
+        The per-world previous Nesterov acceleration variables.\n
         Only allocated if acceleration is enabled.\n
         Shape of ``(num_worlds,)`` and type :class:`float32`.
         """
 
         self.a_factor: wp.array | None = None
         """
-        The per-world Nesterov acceleration factor.\n
+        The per-world current Nesterov acceleration factor.\n
         Only allocated if acceleration is enabled.\n
         Shape of ``(num_worlds,)`` and type :class:`float32`.
         """


### PR DESCRIPTION
## Description

PADMM: fix CPU race in fused Nesterov update by precomputing `a_factor`.
This stabilizes the accelerated solve on CPU when fused accel/cache kernel races on `a_p`
