### PR TITLE
Minor fixes to address PR comments

### DIFF
--- a/newton/_src/solvers/kamino/_src/core/control.py
+++ b/newton/_src/solvers/kamino/_src/core/control.py
@@ -117,7 +117,7 @@ class ControlKamino:
             raise ValueError("Error copying from/to uninitialized ControlKamino")
         wp.copy(self.tau_j, other.tau_j)
 
-    def finalize(self, model: ModelKamino) -> None:
+    def finalize(self, model: ModelKamino, device: wp.DeviceLike = None) -> None:
         """
         Allocates any required internal buffer to interface with a :class:`newton.Control`.
 
@@ -127,13 +127,17 @@ class ControlKamino:
 
         Args:
             model: The Kamino model describing the system.
+            device: Optional device to create the state on. If not specified, the model's device is used.
         """
+        if device is None:
+            device = model.device
+
         if model.size.sum_of_num_joint_dofs != model.size.sum_of_num_joint_coords:
             self._needs_coord_conversion = True
             self._q_j_ref_coords_space = wp.zeros(
                 shape=model.size.sum_of_num_joint_coords,
                 dtype=float32,
-                device=model.device,
+                device=device,
             )
         else:
             self._needs_coord_conversion = False

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -1541,9 +1541,10 @@ def convert_geometries(
     model_size.max_of_num_material_pairs = materials_manager.num_material_pairs
 
     # Convert shapes to the Kamino data structure
-    geom_gid = wp.zeros((model.shape_count,), dtype=int32)
-    geom_material = wp.from_numpy(geom_material_np, dtype=int32)
-    model_num_collidable_geoms = wp.zeros((1,), dtype=int32)
+    with wp.ScopedDevice(model.device):
+        geom_gid = wp.zeros((model.shape_count,), dtype=int32)
+        geom_material = wp.from_numpy(geom_material_np, dtype=int32)
+        model_num_collidable_geoms = wp.zeros((1,), dtype=int32)
 
     wp.launch(
         kernel=geometry_conversion_kernel,

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -79,14 +79,15 @@ def entity_local_transform_conversion_kernel(
 
         # If the parent body was previously corrected, first update this
         # joint's parent-side transform to the new parent frame.
-        parent_corr = body_corr[parent_id]
         joint_X_p_j = joint_X_p[joint_id]
-        if parent_id >= 0 and not parent_corr[3] == 1.0:
-            p_pos = wp.transform_get_translation(joint_X_p_j)
-            wp.transform_set_translation(joint_X_p_j, wp.quat_rotate_inv(parent_corr, p_pos))
-            p_quat = wp.transform_get_rotation(joint_X_p_j)
-            wp.transform_set_rotation(joint_X_p_j, wp.quat_inverse(parent_corr) * p_quat)
-            joint_X_p[joint_id] = joint_X_p_j
+        if parent_id >= 0:
+            parent_corr = body_corr[parent_id]
+            if not parent_corr[3] == 1.0:
+                p_pos = wp.transform_get_translation(joint_X_p_j)
+                wp.transform_set_translation(joint_X_p_j, wp.quat_rotate_inv(parent_corr, p_pos))
+                p_quat = wp.transform_get_rotation(joint_X_p_j)
+                wp.transform_set_rotation(joint_X_p_j, wp.quat_inverse(parent_corr) * p_quat)
+                joint_X_p[joint_id] = joint_X_p_j
 
         # Now compute the correction for this joint's child body
         joint_X_c_j = joint_X_c[joint_id]
@@ -144,6 +145,9 @@ def shape_transform_conversion_kernel(
     shape_id = wp.tid()
 
     body_id = model_shape_body[shape_id]
+    if body_id < 0:
+        return
+
     q_corr_inv = wp.quat_inverse(body_corr[body_id])
 
     st = shape_transform[shape_id]

--- a/newton/_src/solvers/kamino/_src/core/conversions.py
+++ b/newton/_src/solvers/kamino/_src/core/conversions.py
@@ -727,7 +727,7 @@ def convert_entity_local_transforms(model: Model) -> dict[str, wp.array]:
     # to all downstream joints that reference the corrected body as parent.
     # body_corr: dict[int, np.ndarray] = {}  # body_index -> cumulative q_corr
     body_corr = wp.full(
-        shape=(model.joint_count,), value=wp.quat_identity(dtype=float32), dtype=quatf, device=model.device
+        shape=(model.body_count,), value=wp.quat_identity(dtype=float32), dtype=quatf, device=model.device
     )
 
     # Convert bodies, sequentially per world

--- a/newton/_src/solvers/kamino/_src/core/joints.py
+++ b/newton/_src/solvers/kamino/_src/core/joints.py
@@ -1033,16 +1033,10 @@ class JointDoFType(IntEnum):
             R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
         elif dof_type == JointDoFType.CARTESIAN:
             R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
-
-        elif dof_type == JointDoFType.FIXED:
-            assert wp.norm_l2(dof_axes[0] - dof_axes[3]) < 1e-6, "Linear and rotational axes for fixed joint must match"
-            assert wp.norm_l2(dof_axes[1] - dof_axes[4]) < 1e-6, "Linear and rotational axes for fixed joint must match"
-            assert wp.norm_l2(dof_axes[2] - dof_axes[5]) < 1e-6, "Linear and rotational axes for fixed joint must match"
-            R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
         elif dof_type == JointDoFType.FREE:
-            assert wp.norm_l2(dof_axes[0] - dof_axes[3]) < 1e-6, "Linear and rotational axes for fixed joint must match"
-            assert wp.norm_l2(dof_axes[1] - dof_axes[4]) < 1e-6, "Linear and rotational axes for fixed joint must match"
-            assert wp.norm_l2(dof_axes[2] - dof_axes[5]) < 1e-6, "Linear and rotational axes for fixed joint must match"
+            assert wp.norm_l2(dof_axes[0] - dof_axes[3]) < 1e-6, "Linear and rotational axes for free joint must match"
+            assert wp.norm_l2(dof_axes[1] - dof_axes[4]) < 1e-6, "Linear and rotational axes for free joint must match"
+            assert wp.norm_l2(dof_axes[2] - dof_axes[5]) < 1e-6, "Linear and rotational axes for free joint must match"
             R_axis_j = wp.matrix_from_cols(dof_axes[0], dof_axes[1], dof_axes[2])
 
         # Return the computed joint axes rotation matrix

--- a/newton/_src/solvers/kamino/_src/core/model.py
+++ b/newton/_src/solvers/kamino/_src/core/model.py
@@ -665,7 +665,7 @@ class ModelKamino:
         # NOTE: This is currently necessary to handle the case when
         # the total number of joint coordinates and DoFs differ, in
         # which case a temporary buffer is allocated for the conversion.
-        control.finalize(self)
+        control.finalize(self, device=device)
 
         # Return the constructed control container
         return control

--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -137,8 +137,18 @@ def _build_delassus_elementwise_dense(
     if tid >= n_upper:
         return
 
-    # Recover row i: largest i such that f(i) <= tid
-    i = int(float32(2 * ncts + 1) - wp.sqrt(float32((2 * ncts + 1) * (2 * ncts + 1) - 8 * tid))) // 2
+    # Recover row i: largest i such that f(i) <= tid (integer binary search; avoids float32 sqrt)
+    lo = int32(0)
+    hi = ncts - int32(1)
+    i = int32(0)
+    while lo <= hi:
+        mid = lo + (hi - lo) // 2
+        fi = mid * ncts - mid * (mid - 1) // 2
+        if fi <= tid:
+            i = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
     # Recover column j: offset within row i, shifted by i (upper triangle starts at diagonal)
     j = tid - i * ncts + i * (i + 1) // 2
     if i < 0 or i >= ncts or j < i or j >= ncts:

--- a/newton/_src/solvers/kamino/_src/dynamics/delassus.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/delassus.py
@@ -98,6 +98,53 @@ wp.set_module_options({"enable_backward": False})
 
 
 ###
+# Helpers
+###
+
+
+@wp.func
+def upper_triangular_indices_from_index(index: int, mat_size: int):
+    """
+    Maps a single index to a pair of indices of the upper triangular part of a
+    quadratic matrix.
+
+    Args:
+        index: Single index.
+        mat_size: Size of the matrix (number of rows or columns).
+
+    Returns:
+        Pair of matrix indices for the upper triangular part of the matrix, or
+        `-1, -1` if the input index is outside the valid range.
+    """
+    # Map input index to upper-triangular index (i, j):
+    #   Row i starts at flat position f(i) = i * mat_size - i * (i - 1) / 2
+    #   and contains (mat_size - i) elements.
+    # Total elements = mat_size * (mat_size + 1) / 2.
+
+    # Return invalid indices if index is outside of valid range.
+    if index < 0 or index >= mat_size * (mat_size + 1) // 2:
+        return -1, -1
+
+    # Recover row i: largest i such that f(i) <= index (integer binary search; avoids float32 sqrt)
+    lo = int32(0)
+    hi = mat_size - int32(1)
+    i = int32(0)
+    while lo <= hi:
+        mid = lo + (hi - lo) // 2
+        fi = mid * mat_size - mid * (mid - 1) // 2
+        if fi <= index:
+            i = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+
+    # Recover column j: offset within row i, shifted by i (upper triangle starts at diagonal)
+    j = index - i * mat_size + i * (i + 1) // 2
+
+    return i, j
+
+
+###
 # Kernels
 ###
 
@@ -130,27 +177,8 @@ def _build_delassus_elementwise_dense(
         return
 
     # The Delassus matrix is symmetric, so we only compute the upper triangle (i <= j).
-    # Map tid to upper-triangular index (i, j):
-    #   Row i starts at flat position f(i) = i*ncts - i*(i-1)/2
-    #   and contains (ncts - i) elements. Total elements = ncts*(ncts+1)/2.
-    n_upper = ncts * (ncts + 1) // 2
-    if tid >= n_upper:
-        return
-
-    # Recover row i: largest i such that f(i) <= tid (integer binary search; avoids float32 sqrt)
-    lo = int32(0)
-    hi = ncts - int32(1)
-    i = int32(0)
-    while lo <= hi:
-        mid = lo + (hi - lo) // 2
-        fi = mid * ncts - mid * (mid - 1) // 2
-        if fi <= tid:
-            i = mid
-            lo = mid + 1
-        else:
-            hi = mid - 1
-    # Recover column j: offset within row i, shifted by i (upper triangle starts at diagonal)
-    j = tid - i * ncts + i * (i + 1) // 2
+    # Recover matrix indices from tid.
+    i, j = upper_triangular_indices_from_index(tid, ncts)
     if i < 0 or i >= ncts or j < i or j >= ncts:
         return
 

--- a/newton/_src/solvers/kamino/_src/dynamics/dual.py
+++ b/newton/_src/solvers/kamino/_src/dynamics/dual.py
@@ -1089,6 +1089,10 @@ class DualProblem:
                 generalized forces vectors in construction of the dual problem.\n
                 Defaults to `False`.
         """
+        # Ensure Jacobians are given if model is provided.
+        if model is not None and jacobians is None:
+            raise ValueError("`jacobians` parameter must be provided if `model` parameter is specified.")
+
         # Declare the device cache
         self._device: wp.DeviceLike = None
 

--- a/newton/_src/solvers/kamino/_src/geometry/primitive/broadphase.py
+++ b/newton/_src/solvers/kamino/_src/geometry/primitive/broadphase.py
@@ -376,7 +376,7 @@ def aabb_box(pose: transformf, half_extents: vec3f, margin: float32) -> vec6f:
 
 # TODO: Implement proper AABB for planes
 @wp.func
-def aabb_plane(pose: transformf, normal: vec3f, distance: float32, margin: float32) -> vec6f:
+def aabb_plane(pose: transformf, width: float32, length: float32, margin: float32) -> vec6f:
     return vec6f(0.0)
 
 
@@ -407,7 +407,7 @@ def aabb_geom(sid: int32, params: vec3f, margin: float32, pose: transformf) -> v
     elif sid == GeoType.BOX:
         aabb = aabb_box(pose, params, margin)
     elif sid == GeoType.PLANE:
-        aabb = aabb_plane(pose, params, params[3], margin)
+        aabb = aabb_plane(pose, params[0], params[1], margin)
     return aabb
 
 

--- a/newton/_src/solvers/kamino/_src/geometry/unified.py
+++ b/newton/_src/solvers/kamino/_src/geometry/unified.py
@@ -444,6 +444,7 @@ class CollisionPipelineUnifiedKamino:
                 if uwid >= 0:
                     n = count + global_count
                     per_world_pairs += (n * (n - 1)) // 2
+            per_world_pairs += (global_count * (global_count - 1)) // 2
             self._max_shape_pairs: int = int(per_world_pairs)
         else:
             self._max_shape_pairs: int = (self._num_geoms * (self._num_geoms - 1)) // 2

--- a/newton/_src/solvers/kamino/_src/geometry/unified.py
+++ b/newton/_src/solvers/kamino/_src/geometry/unified.py
@@ -433,8 +433,9 @@ class CollisionPipelineUnifiedKamino:
         # Compute the maximum possible number of geom pairs per world and sum
         # them.  The naive global formula N*(N-1)/2 is O(W^2 * S^2) for W
         # worlds with S shapes each; the per-world sum is O(W * S^2).
-        # Global geoms (wid == -1) participate in every regular-world slice
-        # plus a dedicated global-only segment, matching precompute_world_map.
+        # Global geoms (wid == -1) participate in every regular-world slice.
+        # Deviating from `precompute_world_map`, the maximum number of pairs
+        # does not consider a dedicated global-only segment for global geoms.
         if self._model.geoms.wid is not None:
             wid_np = self._model.geoms.wid.numpy()
             unique_wids, counts = np.unique(wid_np, return_counts=True)
@@ -444,7 +445,6 @@ class CollisionPipelineUnifiedKamino:
                 if uwid >= 0:
                     n = count + global_count
                     per_world_pairs += (n * (n - 1)) // 2
-            per_world_pairs += (global_count * (global_count - 1)) // 2
             self._max_shape_pairs: int = int(per_world_pairs)
         else:
             self._max_shape_pairs: int = (self._num_geoms * (self._num_geoms - 1)) // 2

--- a/newton/_src/solvers/kamino/_src/models/builders/utils.py
+++ b/newton/_src/solvers/kamino/_src/models/builders/utils.py
@@ -18,7 +18,6 @@ from collections.abc import Callable
 
 import warp as wp
 
-from ....examples import print_progress_bar
 from ...core.builder import ModelBuilderKamino
 from ...core.shapes import BoxShape, PlaneShape
 from ...core.types import transformf, vec3f, vec6f
@@ -210,6 +209,8 @@ def make_homogeneous_builder(num_worlds: int, build_fn: Callable, show_progress=
     start_time = time.time()
     for i in range(num_worlds):
         if show_progress:
+            from ....examples import print_progress_bar  # noqa: PLC0415
+
             print_progress_bar(i + 1, num_worlds, start_time, prefix="Adding builders", suffix="")
         builder.add_builder(single)
     return builder

--- a/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
+++ b/newton/_src/solvers/kamino/_src/solvers/fk/kernels.py
@@ -1196,7 +1196,7 @@ def _eval_linear_combination(
         z: Output stack of vectors
     """
     wd_id, row_id = wp.tid()  # Thread indices (= world index, row index)
-    if wd_id < num_rows.shape[0] and row_id < num_rows[wd_id]:
+    if wd_id < num_rows.shape[0] and world_mask[wd_id] != 0 and row_id < num_rows[wd_id]:
         z[wd_id, row_id] = alpha * x[wd_id, row_id] + beta * y[wd_id, row_id]
 
 

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -714,21 +714,15 @@ def _compute_joint_kinematics_residual_dense(
             for i in range(6):
                 j_v_j[j] += jacobian_cts_data[mio_j + i] * u_i_B[i]
 
-    # Compute the per-joint kinematics residual (inf norm) and local argmax row
-    r_kinematics_j = float32(0.0)
-    kin_argmax_local = int32(0)
-    if num_cts_j > 0:
-        r_kinematics_j = wp.abs(j_v_j[0])
-        for k in range(1, num_cts_j):
-            ak = wp.abs(j_v_j[k])
-            if ak > r_kinematics_j:
-                r_kinematics_j = ak
-                kin_argmax_local = int32(k)
+    # Compute the per-joint kinematics residual and local argmax
+    j_v_j_abs = wp.abs(j_v_j)
+    kin_argmax_local = wp.argmax(j_v_j_abs)
+    r_kinematics_j = j_v_j_abs[kin_argmax_local]
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
     if r_kinematics_j >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cts_offset_j - kgo + kin_argmax_local)))
+        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cts_offset_j - kgo) + kin_argmax_local))
         wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
 
 
@@ -780,21 +774,15 @@ def _compute_joint_kinematics_residual_sparse(
             jac_block = jac_nzb_values[jac_j_nzb_start + num_kin_cts_j + j]
             j_v_j[j] += wp.dot(jac_block, u_i_B)
 
-    # Compute the per-joint kinematics residual (inf norm) and local argmax row
-    r_kinematics_j = float32(0.0)
-    kin_argmax_local = int32(0)
-    if num_kin_cts_j > 0:
-        r_kinematics_j = wp.abs(j_v_j[0])
-        for k in range(1, num_kin_cts_j):
-            ak = wp.abs(j_v_j[k])
-            if ak > r_kinematics_j:
-                r_kinematics_j = ak
-                kin_argmax_local = int32(k)
+    # Compute the per-joint kinematics residual and local argmax
+    j_v_j_abs = wp.abs(j_v_j)
+    kin_argmax_local = wp.argmax(j_v_j_abs)
+    r_kinematics_j = j_v_j_abs[kin_argmax_local]
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
     if r_kinematics_j >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(kin_cts_offset_j + kin_argmax_local)))
+        argmax_key = int64(build_pair_key2(uint32(jid), uint32(kin_cts_offset_j) + kin_argmax_local))
         wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
 
 

--- a/newton/_src/solvers/kamino/_src/solvers/metrics.py
+++ b/newton/_src/solvers/kamino/_src/solvers/metrics.py
@@ -714,13 +714,21 @@ def _compute_joint_kinematics_residual_dense(
             for i in range(6):
                 j_v_j[j] += jacobian_cts_data[mio_j + i] * u_i_B[i]
 
-    # Compute the per-joint kinematics residual
-    r_kinematics_j = wp.max(wp.abs(j_v_j))
+    # Compute the per-joint kinematics residual (inf norm) and local argmax row
+    r_kinematics_j = float32(0.0)
+    kin_argmax_local = int32(0)
+    if num_cts_j > 0:
+        r_kinematics_j = wp.abs(j_v_j[0])
+        for k in range(1, num_cts_j):
+            ak = wp.abs(j_v_j[k])
+            if ak > r_kinematics_j:
+                r_kinematics_j = ak
+                kin_argmax_local = int32(k)
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
     if r_kinematics_j >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cts_offset_j - kgo)))
+        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cts_offset_j - kgo + kin_argmax_local)))
         wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
 
 
@@ -772,13 +780,21 @@ def _compute_joint_kinematics_residual_sparse(
             jac_block = jac_nzb_values[jac_j_nzb_start + num_kin_cts_j + j]
             j_v_j[j] += wp.dot(jac_block, u_i_B)
 
-    # Compute the per-joint kinematics residual
-    r_kinematics_j = wp.max(wp.abs(j_v_j))
+    # Compute the per-joint kinematics residual (inf norm) and local argmax row
+    r_kinematics_j = float32(0.0)
+    kin_argmax_local = int32(0)
+    if num_kin_cts_j > 0:
+        r_kinematics_j = wp.abs(j_v_j[0])
+        for k in range(1, num_kin_cts_j):
+            ak = wp.abs(j_v_j[k])
+            if ak > r_kinematics_j:
+                r_kinematics_j = ak
+                kin_argmax_local = int32(k)
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_kinematics, wid, r_kinematics_j)
     if r_kinematics_j >= previous_max:
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(kin_cts_offset_j)))
+        argmax_key = int64(build_pair_key2(uint32(jid), uint32(kin_cts_offset_j + kin_argmax_local)))
         wp.atomic_exch(metric_r_kinematics_argmax, wid, argmax_key)
 
 
@@ -802,16 +818,22 @@ def _compute_cts_joints_residual(
     num_cts_j = model_joint_num_kinematic_cts[jid]
     cio_j = model_joint_kinematic_cts_offset[jid]
 
-    # Compute the per-joint constraint residual (infinity-norm)
+    # Compute the per-joint constraint residual (infinity-norm) and local argmax row
     r_cts_joints_j = float32(0.0)
-    for j in range(num_cts_j):
-        r_cts_joints_j = wp.max(r_cts_joints_j, wp.abs(data_joints_r_j[cio_j + j]))
+    argmax_j = int32(0)
+    if num_cts_j > 0:
+        r_cts_joints_j = wp.abs(data_joints_r_j[cio_j])
+        for j in range(1, num_cts_j):
+            v = wp.abs(data_joints_r_j[cio_j + j])
+            if v > r_cts_joints_j:
+                r_cts_joints_j = v
+                argmax_j = int32(j)
 
     # Update the per-world maximum residual and argmax index
     previous_max = wp.atomic_max(metric_r_cts_joints, wid, r_cts_joints_j)
     if r_cts_joints_j >= previous_max:
         cio_j_loc = cio_j - model_info_joint_kinematic_cts_offset[wid]
-        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cio_j_loc)))
+        argmax_key = int64(build_pair_key2(uint32(jid), uint32(cio_j_loc + argmax_j)))
         wp.atomic_exch(metric_r_cts_joints_argmax, wid, argmax_key)
 
 

--- a/newton/_src/solvers/kamino/_src/utils/logger.py
+++ b/newton/_src/solvers/kamino/_src/utils/logger.py
@@ -14,14 +14,21 @@ from typing import ClassVar
 if sys.platform == "win32":
     import ctypes
 
+    # Enable VT sequences only when stdout is a real console.
     kernel32 = ctypes.windll.kernel32
-    handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
-
-    mode = ctypes.c_uint()
-    kernel32.GetConsoleMode(handle, ctypes.byref(mode))
-
-    mode.value |= 0x0004  # ENABLE_VIRTUAL_TERMINAL_PROCESSING
-    kernel32.SetConsoleMode(handle, mode)
+    try:
+        handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        invalid_handle = ctypes.c_void_p(-1).value
+        if handle != 0 and ctypes.c_void_p(handle).value != invalid_handle:
+            mode = ctypes.c_uint()
+            if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+                new_mode = mode.value | 0x0004  # Set ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                if new_mode != mode.value:
+                    kernel32.SetConsoleMode(handle, new_mode)
+    except Exception:
+        # For some contexts, getting/setting the console mode fails (e.g.,
+        # redirected stdout, services, CI).
+        pass
 
 
 class LogLevel(IntEnum):

--- a/newton/_src/solvers/kamino/_src/utils/sim/datalog.py
+++ b/newton/_src/solvers/kamino/_src/utils/sim/datalog.py
@@ -293,7 +293,7 @@ class SimulationLogger:
         num_iters_data = self.log_padmm_iters[: self._frames]
         self.plt.hist(
             num_iters_data - 0.5,  # Center histogram bar at integer values for readability
-            bins=np.max(num_iters_data) - np.min(num_iters_data),  # Ensure there is one bar per integer
+            bins=np.max(num_iters_data) - np.min(num_iters_data) + 1,  # Ensure there is one bar per integer
         )
         self.plt.yscale("log")  # Make Y-axis logarithmic
         self.plt.title("Histogram of PADMM Solver Iterations")

--- a/newton/_src/solvers/kamino/_src/utils/sim/datalog.py
+++ b/newton/_src/solvers/kamino/_src/utils/sim/datalog.py
@@ -292,9 +292,14 @@ class SimulationLogger:
         self.plt.grid(True, which="minor", linestyle=":", linewidth=0.25)
         num_iters_data = self.log_padmm_iters[: self._frames]
         self.plt.hist(
-            num_iters_data - 0.5,  # Center histogram bar at integer values for readability
-            bins=np.max(num_iters_data) - np.min(num_iters_data) + 1,  # Ensure there is one bar per integer
+            num_iters_data,
+            bins=max(1, np.max(num_iters_data) - np.min(num_iters_data) + 1),  # Ensure there is one bar per integer
+            range=(
+                np.min(num_iters_data) - 0.5,
+                np.max(num_iters_data) + 0.5,
+            ),  # Center histogram bar at integer values
         )
+        self.plt.gca().xaxis.get_major_locator().set_params(integer=True)
         self.plt.yscale("log")  # Make Y-axis logarithmic
         self.plt.title("Histogram of PADMM Solver Iterations")
         self.plt.xlabel("Iterations")

--- a/newton/_src/solvers/kamino/examples/__init__.py
+++ b/newton/_src/solvers/kamino/examples/__init__.py
@@ -15,7 +15,7 @@ from .._src.utils import logger as msg
 
 
 def get_examples_output_path() -> str:
-    path = os.path.dirname(os.path.realpath(__file__)) + "/output"
+    path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "output")
     if not os.path.exists(path):
         os.makedirs(path)
     return path


### PR DESCRIPTION
## Description

This should address all of the AI PR comments that I thought would warrant a fix. Each commit should translate (roughly) to a comment that was addressed, this might make it a bit easier to see why things were modified.

One interesting comment was on the computation for the matrix indices in the assembly of the dense Delassus matrix. We switched to just assembling the upper triangular part and mirroring it. The operation to compute the row/col indices from the single index for the kernel uses a square root operation, which can run into floating point issues for large numbers. I was able to confirm that for matrices starting at a size of around 5000x5000, this would lead to some wrong indices, so we would compute some entries twice and skip some other entries. I don't think we would run into this for our current models, but I think it's still good to have a more robust approach.