### PR TITLE
SolverMuJoCo Equality-constraint joint wrenches

### DIFF
--- a/newton/_src/solvers/kamino/_src/metrics/mujoco.py
+++ b/newton/_src/solvers/kamino/_src/metrics/mujoco.py
@@ -54,14 +54,14 @@ _vec11 = wp.types.vector(length=11, dtype=wp.float32)
 
 def _mjw_eq_type_connect() -> int:
     """Lazy import of ``mujoco_warp._src.types.EqType.CONNECT`` as an int."""
-    from mujoco_warp._src.types import EqType  # noqa: PLC0415
+    from mujoco_warp._src.types import EqType
 
     return int(EqType.CONNECT)
 
 
 def _mjw_constraint_type_equality() -> int:
     """Lazy import of ``mujoco_warp._src.types.ConstraintType.EQUALITY`` as an int."""
-    from mujoco_warp._src.types import ConstraintType  # noqa: PLC0415
+    from mujoco_warp._src.types import ConstraintType
 
     return int(ConstraintType.EQUALITY)
 
@@ -461,9 +461,7 @@ def populate_joint_parent_f_from_mjw_connect_equalities(
         return
 
     if connect_constraint_force is None:
-        connect_constraint_force = wp.zeros(
-            shape=(nworld, neq), dtype=wp.spatial_vectorf, device=model.device
-        )
+        connect_constraint_force = wp.zeros(shape=(nworld, neq), dtype=wp.spatial_vectorf, device=model.device)
     else:
         connect_constraint_force.zero_()
 

--- a/newton/_src/solvers/kamino/_src/metrics/mujoco.py
+++ b/newton/_src/solvers/kamino/_src/metrics/mujoco.py
@@ -9,6 +9,7 @@ from functools import cache
 
 import warp as wp
 
+from .....sim import Model, State
 from .....solvers.solver import SolverBase
 from ..core.model import ModelKamino
 from ..kinematics.limits import LimitsKamino
@@ -19,6 +20,7 @@ from ..kinematics.limits import LimitsKamino
 
 __all__ = [
     "extract_constraint_reactions_mujoco_warp",
+    "populate_joint_parent_f_from_mjw_connect_equalities",
 ]
 
 
@@ -27,6 +29,15 @@ __all__ = [
 ###
 
 wp.set_module_options({"enable_backward": False})
+
+
+###
+# Local types
+###
+
+# Layout-compatible with ``mujoco_warp._src.types.vec11`` so kernels can read
+# ``efc_data`` rows without forcing a top-level ``mujoco_warp`` import.
+_vec11 = wp.types.vector(length=11, dtype=wp.float32)
 
 
 ###
@@ -39,6 +50,116 @@ wp.set_module_options({"enable_backward": False})
 ###
 # Kernels
 ###
+
+
+def _mjw_eq_type_connect() -> int:
+    """Lazy import of ``mujoco_warp._src.types.EqType.CONNECT`` as an int."""
+    from mujoco_warp._src.types import EqType  # noqa: PLC0415
+
+    return int(EqType.CONNECT)
+
+
+def _mjw_constraint_type_equality() -> int:
+    """Lazy import of ``mujoco_warp._src.types.ConstraintType.EQUALITY`` as an int."""
+    from mujoco_warp._src.types import ConstraintType  # noqa: PLC0415
+
+    return int(ConstraintType.EQUALITY)
+
+
+@wp.kernel
+def _extract_mjw_connect_constraint_force(
+    # Inputs:
+    mjw_eq_type: wp.array[wp.int32],
+    mjw_efc_type: wp.array2d[wp.int32],
+    mjw_efc_id: wp.array2d[wp.int32],
+    mjw_efc_force: wp.array2d[wp.float32],
+    mjw_ne: wp.array[wp.int32],
+    # Outputs:
+    connect_constraint_force: wp.array2d[wp.spatial_vectorf],
+):
+    """
+    Reads the cartesian constraint force of each MuJoCo CONNECT equality from
+    ``efc.force`` and stores it (as a 3-D force in ``spatial_top``, zeros in
+    ``spatial_bottom``) in a per-equality output buffer.
+
+    The kernel scans the ``efc`` rows up to ``ne`` and matches by ``(efc.type ==
+    EQUALITY, efc.id == eq)`` because mujoco_warp allocates ``efc`` rows via
+    ``atomic_add`` -- the row order is non-deterministic.
+    """
+    wid, eq = wp.tid()
+    if mjw_eq_type[eq] != wp.static(_mjw_eq_type_connect()):
+        return
+
+    ne = mjw_ne[wid]
+    efcid = int(-1)
+    for i in range(ne):
+        if mjw_efc_type[wid, i] == wp.static(_mjw_constraint_type_equality()) and mjw_efc_id[wid, i] == eq:
+            efcid = i
+            break
+    if efcid < 0:
+        return
+
+    fx = mjw_efc_force[wid, efcid + 0]
+    fy = mjw_efc_force[wid, efcid + 1]
+    fz = mjw_efc_force[wid, efcid + 2]
+    connect_constraint_force[wid, eq] = wp.spatial_vector(wp.vec3(fx, fy, fz), wp.vec3(0.0))
+
+
+@wp.kernel
+def _accumulate_mjw_connect_force_to_joint_parent_f(
+    # Inputs:
+    mjc_eq_to_newton_jnt: wp.array2d[wp.int32],
+    mjw_eq_data: wp.array2d[_vec11],
+    connect_constraint_force: wp.array2d[wp.spatial_vectorf],
+    joint_parent: wp.array[wp.int32],
+    joint_child: wp.array[wp.int32],
+    body_q: wp.array[wp.transform],
+    body_com: wp.array[wp.vec3],
+    # Outputs:
+    joint_parent_f: wp.array[wp.spatial_vectorf],
+):
+    """
+    Accumulates the per-equality CONNECT constraint force into ``state.joint_parent_f``
+    (Newton convention: world frame, moment referenced to the child body's COM).
+
+    For each CONNECT equality mapped to a Newton loop-closure joint via
+    ``mjc_eq_to_newton_jnt``, the force on the child body (= negation of mujoco_warp's
+    ``efc.force``, since the CONNECT Jacobian is ``pos1 - pos2``) is applied at
+    ``anchor1`` (in body1=parent's local frame, mapped to world). The moment is
+    computed about the child body's COM in world frame.
+
+    Multiple equalities mapping to the same joint accumulate via ``wp.atomic_add``.
+    The output buffer must be zeroed by the caller before invocation.
+    """
+    wid, eq = wp.tid()
+
+    jnt = mjc_eq_to_newton_jnt[wid, eq]
+    if jnt == -1:
+        return
+
+    # Force on child body. mujoco_warp's CONNECT Jacobian is ``pos1 - pos2``, so
+    # ``efc.force`` is the force on body1 (parent); negate to get the force on
+    # body2 (child).
+    f = -wp.spatial_top(connect_constraint_force[wid, eq])
+
+    # ``eq_data[0:3]`` is anchor1 in body1=parent's local frame. Map to world.
+    data = mjw_eq_data[wid % mjw_eq_data.shape[0], eq]
+    anchor1_local = wp.vec3(data[0], data[1], data[2])
+
+    parent = joint_parent[jnt]
+    if parent >= 0:
+        anchor1 = wp.transform_point(body_q[parent], anchor1_local)
+    else:
+        anchor1 = anchor1_local
+
+    # Child body COM in world frame.
+    child = joint_child[jnt]
+    child_com_world = wp.transform_point(body_q[child], body_com[child])
+
+    r = anchor1 - child_com_world
+    moment = wp.cross(r, f)
+
+    wp.atomic_add(joint_parent_f, jnt, wp.spatial_vector(f, moment))
 
 
 @cache
@@ -292,6 +413,88 @@ def unpack_mjw_joint_limited_to_limits_kamino(
             limits_kamino.data.reaction,
         ],
         device=model_kamino.device,
+    )
+
+
+def populate_joint_parent_f_from_mjw_connect_equalities(
+    solver: SolverBase,
+    model: Model,
+    state: State,
+    *,
+    connect_constraint_force: wp.array | None = None,
+):
+    """
+    Populates ``state.joint_parent_f`` with the per-joint constraint wrench induced
+    by MuJoCo CONNECT equality constraints (loop-closure ball joints).
+
+    The output convention matches :attr:`newton.State.joint_parent_f`: world frame,
+    moment referenced to the child body's center of mass. Joints not associated with
+    a CONNECT equality are left untouched -- the caller is expected to zero
+    ``state.joint_parent_f`` (and the optional ``connect_constraint_force`` buffer)
+    before invocation.
+
+    Args:
+        solver: The :class:`SolverMuJoCo` instance whose ``mjw_data.efc.force`` is read.
+        model: The Newton :class:`Model` providing joint topology and body COMs.
+        state: The Newton :class:`State` whose ``joint_parent_f`` is accumulated into.
+            Must have been allocated via ``Model.request_state_attributes("joint_parent_f")``.
+        connect_constraint_force: Optional pre-allocated per-equality scratch buffer
+            of shape ``(nworld, neq)`` and dtype ``wp.spatial_vectorf``. If ``None``,
+            a fresh buffer is allocated on the model's device.
+    """
+    from newton._src.solvers.mujoco.solver_mujoco import SolverMuJoCo  # noqa: PLC0415
+
+    if not isinstance(solver, SolverMuJoCo):
+        raise TypeError(f"`solver` must be an instance of `newton.solvers.SolverMuJoCo`; got {type(solver).__name__}.")
+    if solver.use_mujoco_cpu:
+        raise NotImplementedError(
+            "populate_joint_parent_f_from_mjw_connect_equalities only supports the "
+            "mujoco_warp GPU backend (SolverMuJoCo(use_mujoco_cpu=False))."
+        )
+
+    if state.joint_parent_f is None or model.joint_count == 0:
+        return
+
+    nworld = solver.mjw_data.nworld
+    neq = solver.mjw_model.neq
+    if neq == 0:
+        return
+
+    if connect_constraint_force is None:
+        connect_constraint_force = wp.zeros(
+            shape=(nworld, neq), dtype=wp.spatial_vectorf, device=model.device
+        )
+    else:
+        connect_constraint_force.zero_()
+
+    wp.launch(
+        kernel=_extract_mjw_connect_constraint_force,
+        dim=(nworld, neq),
+        inputs=[
+            solver.mjw_model.eq_type,
+            solver.mjw_data.efc.type,
+            solver.mjw_data.efc.id,
+            solver.mjw_data.efc.force,
+            solver.mjw_data.ne,
+        ],
+        outputs=[connect_constraint_force],
+        device=model.device,
+    )
+
+    wp.launch(
+        kernel=_accumulate_mjw_connect_force_to_joint_parent_f,
+        dim=(nworld, neq),
+        inputs=[
+            solver.mjc_eq_to_newton_jnt,
+            solver.mjw_model.eq_data,
+            connect_constraint_force,
+            model.joint_parent,
+            model.joint_child,
+            state.body_q,
+            model.body_com,
+        ],
+        outputs=[state.joint_parent_f],
+        device=model.device,
     )
 
 

--- a/newton/_src/solvers/kamino/tests/test_metrics_mujoco.py
+++ b/newton/_src/solvers/kamino/tests/test_metrics_mujoco.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 The Newton Developers
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the MuJoCo-side metric extractors in
+:mod:`newton._src.solvers.kamino._src.metrics.mujoco`.
+
+The fourbar asset (``boxes_fourbar_loop.usda``) authors ``joint_4`` with
+``physics:excludeFromArticulation = true`` so MuJoCo encodes it as a pair of
+``mjEQ_CONNECT`` equalities, which is what
+:func:`populate_joint_parent_f_from_mjw_connect_equalities` is built to recover.
+"""
+
+import unittest
+
+import numpy as np
+import warp as wp
+from pxr import Usd, UsdPhysics
+
+import newton
+import newton.examples
+from newton._src.solvers.kamino._src.metrics.mujoco import (
+    populate_joint_parent_f_from_mjw_connect_equalities,
+)
+from newton._src.solvers.kamino.tests import setup_tests, test_context
+
+###
+# Module-level constants
+###
+
+_cuda_available = wp.is_cuda_available()
+
+# Path of the loop-closing joint in ``boxes_fourbar_loop.usda``. ``add_usd``
+# imports it under the asset's default-prim namespace.
+_LOOP_CLOSER_JOINT_LABEL = "/boxes_fourbar/Joints/joint_4"
+_ROOT_BODY_LABEL = "/boxes_fourbar/RigidBodies/body_1"
+_PINNED_FIXED_JOINT_LABEL = "/boxes_fourbar/Joints/joint_world"
+
+
+###
+# Tests
+###
+
+
+@unittest.skipUnless(_cuda_available, "SolverMuJoCo Warp backend requires CUDA")
+class TestMetricsMujocoConnect(unittest.TestCase):
+    """End-to-end check of the ``CONNECT`` -> ``joint_parent_f`` pipeline."""
+
+    def setUp(self):
+        if not test_context.setup_done:
+            setup_tests(clear_cache=False)
+        self.device = wp.get_device(test_context.device)
+
+    def _open_fourbar_stage(self, *, pin_root: bool) -> Usd.Stage:
+        """Open ``boxes_fourbar_loop.usda`` in-memory; optionally insert a
+        ``PhysicsFixedJoint`` from world to ``body_1`` so the linkage's root
+        body is grounded (no auto-inserted floating-base joint)."""
+        asset_file = newton.examples.get_asset("boxes_fourbar_loop.usda")
+        stage = Usd.Stage.Open(asset_file)
+        if stage is None:
+            self.fail(f"Failed to open USD stage: {asset_file}")
+        if pin_root:
+            fixed = UsdPhysics.FixedJoint.Define(stage, _PINNED_FIXED_JOINT_LABEL)
+            # Leaving body0 empty makes this a fixed-to-world joint.
+            fixed.CreateBody1Rel().SetTargets([_ROOT_BODY_LABEL])
+        return stage
+
+    def _build_fourbar(self, *, pin_root: bool = False):
+        """Construct a single-world fourbar model + ``SolverMuJoCo`` mirroring
+        ``newton/examples/robot/example_fourbar.py``. If ``pin_root`` is True,
+        ``body_1`` is fixed to the world (no auto-inserted free joint)."""
+        articulation = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        newton.solvers.SolverMuJoCo.register_custom_attributes(articulation)
+        articulation.default_shape_cfg.ke = 2.0e3
+        articulation.default_shape_cfg.kd = 1.0e2
+        articulation.default_shape_cfg.kf = 1.0e3
+        articulation.default_shape_cfg.mu = 0.75
+
+        stage = self._open_fourbar_stage(pin_root=pin_root)
+        articulation.add_usd(
+            stage,
+            enable_self_collisions=False,
+            hide_collision_shapes=False,
+        )
+
+        if not pin_root:
+            # Lift the auto-inserted free joint so the linkage spawns above the ground.
+            articulation.joint_q[:3] = [0.0, 0.0, 0.1]
+            if len(articulation.joint_q) > 6:
+                articulation.joint_q[3:7] = [0.0, 0.0, 0.0, 1.0]
+
+        builder = newton.ModelBuilder(up_axis=newton.Axis.Z)
+        builder.add_world(articulation)
+        builder.default_shape_cfg.ke = 1.0e3
+        builder.default_shape_cfg.kd = 1.0e2
+        builder.add_ground_plane()
+
+        builder.request_state_attributes("joint_parent_f", "body_parent_f")
+
+        model = builder.finalize()
+
+        solver = newton.solvers.SolverMuJoCo(
+            model,
+            use_mujoco_cpu=False,
+            cone="elliptic",
+            impratio=100,
+            iterations=100,
+            ls_iterations=50,
+            nconmax=64,
+            njmax=128,
+            use_mujoco_contacts=True,
+        )
+
+        return model, solver
+
+    def _loop_closer_joint_index(self, model: newton.Model) -> int:
+        """Resolve the loop-closer joint's index from ``model.joint_label``."""
+        labels = list(model.joint_label)
+        if _LOOP_CLOSER_JOINT_LABEL not in labels:
+            self.fail(
+                f"Expected joint label {_LOOP_CLOSER_JOINT_LABEL!r} not found in model. Available labels: {labels}"
+            )
+        return labels.index(_LOOP_CLOSER_JOINT_LABEL)
+
+    def test_00_finalize_smoke(self):
+        """Construct the model + solver and verify the loop closer is in the
+        joint set (i.e. the USD ``excludeFromArticulation`` flag did not strip it)."""
+        model, _ = self._build_fourbar()
+        self.assertGreater(model.joint_count, 0)
+        # Assert allocation of the requested extended-state attribute.
+        state = model.state()
+        self.assertIsNotNone(state.joint_parent_f)
+        self.assertEqual(state.joint_parent_f.shape, (model.joint_count,))
+        # Loop closer must be present as a Newton joint (it just isn't in MuJoCo's
+        # articulation tree -- it lives as an EQ_CONNECT instead).
+        self._loop_closer_joint_index(model)
+
+    def test_01_populate_joint_parent_f_fourbar(self):
+        """Step the fourbar once and verify the launcher writes a non-zero
+        wrench into ``state.joint_parent_f`` at the loop-closer joint, and
+        leaves every other joint at zero."""
+        model, solver = self._build_fourbar()
+
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        contacts = newton.Contacts(solver.get_max_contact_count(), 0)
+
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+        # One sub-step is enough to produce non-trivial CONNECT reactions.
+        sim_dt = 1.0 / 200.0
+        state_0.clear_forces()
+        solver.step(state_0, state_1, control, contacts, sim_dt)
+
+        # Caller contract: zero ``joint_parent_f`` before invocation.
+        state_1.joint_parent_f.zero_()
+        populate_joint_parent_f_from_mjw_connect_equalities(solver, model, state_1)
+        wp.synchronize()
+
+        jpf = state_1.joint_parent_f.numpy()
+        self.assertEqual(jpf.shape, (model.joint_count, 6))
+
+        loop_idx = self._loop_closer_joint_index(model)
+
+        # Loop closer must carry a non-trivial reaction wrench.
+        loop_wrench = jpf[loop_idx]
+        self.assertGreater(
+            np.linalg.norm(loop_wrench),
+            0.0,
+            msg=f"Expected non-zero wrench at loop-closer joint {loop_idx}, got {loop_wrench}.",
+        )
+
+        # The launcher must touch only CONNECT-equality joints. Every other
+        # joint in the model is part of MuJoCo's articulation tree and must
+        # remain at the (caller-zeroed) baseline.
+        mask = np.ones(model.joint_count, dtype=bool)
+        mask[loop_idx] = False
+        non_loop = jpf[mask]
+        np.testing.assert_array_equal(
+            non_loop,
+            np.zeros_like(non_loop),
+            err_msg="Non-loop-closer joints unexpectedly received a wrench from the launcher.",
+        )
+
+    def test_02_force_balance_pinned_root(self):
+        """Pin ``body_1`` to the world via a fixed joint and verify linear
+        force balance on the pinned body.
+
+        With ``body_1`` immobilized (zero velocity, zero acceleration) Newton's
+        2nd law on the linear axes reduces to::
+
+            F_gravity_body_1
+            + body_parent_f[body_1].linear   # from the pin (fixed-to-world joint)
+            + joint_parent_f[loop_idx].linear  # from the loop closer (CONNECT)
+            == 0
+
+        because ``joint_4``'s child in ``boxes_fourbar_loop.usda`` is ``body_1``,
+        so the launcher's output is the wrench *applied on body_1* by the loop
+        closer. We verify the linear residual only -- torques are off-axis from
+        the joint anchor by the COM lever arm and are not part of this check.
+        """
+        model, solver = self._build_fourbar(pin_root=True)
+
+        state_0 = model.state()
+        state_1 = model.state()
+        control = model.control()
+        contacts = newton.Contacts(solver.get_max_contact_count(), 0)
+
+        newton.eval_fk(model, model.joint_q, model.joint_qd, state_0)
+
+        sim_dt = 1.0 / 200.0
+        state_0.clear_forces()
+        solver.step(state_0, state_1, control, contacts, sim_dt)
+
+        # Caller contract: zero ``joint_parent_f`` before invocation. ``body_parent_f``
+        # is populated by ``solver.step`` (via the MuJoCo body-parent kernel).
+        state_1.joint_parent_f.zero_()
+        populate_joint_parent_f_from_mjw_connect_equalities(solver, model, state_1)
+        wp.synchronize()
+
+        body_labels = list(model.body_label)
+        if _ROOT_BODY_LABEL not in body_labels:
+            self.fail(f"Expected body label {_ROOT_BODY_LABEL!r} not found in model. Available labels: {body_labels}")
+        root_body_idx = body_labels.index(_ROOT_BODY_LABEL)
+        loop_idx = self._loop_closer_joint_index(model)
+
+        # Sanity: the loop closer's child must be body_1 -- otherwise the
+        # ``joint_parent_f`` entry isn't on the pinned body and the equation
+        # below doesn't apply.
+        joint_child = model.joint_child.numpy()
+        self.assertEqual(
+            int(joint_child[loop_idx]),
+            root_body_idx,
+            f"Expected loop-closer joint to have body_1 as child; "
+            f"got child={joint_child[loop_idx]}, expected {root_body_idx}.",
+        )
+
+        body_parent_f = state_1.body_parent_f.numpy()
+        joint_parent_f = state_1.joint_parent_f.numpy()
+        gravity = model.gravity[0]  # one world; shape (3,)
+        body_mass = float(model.body_mass.numpy()[root_body_idx])
+
+        # Linear-only residual.
+        f_grav = body_mass * np.asarray(gravity, dtype=np.float64)
+        f_pin = body_parent_f[root_body_idx, :3].astype(np.float64)
+        f_loop = joint_parent_f[loop_idx, :3].astype(np.float64)
+        residual = f_grav + f_pin + f_loop
+
+        # Sanity: the loop closer must actually carry a non-zero linear force
+        # (otherwise we'd trivially satisfy the residual check just by
+        # body_parent_f cancelling gravity, without exercising the launcher).
+        self.assertGreater(
+            np.linalg.norm(f_loop),
+            0.0,
+            msg=f"Expected non-zero loop-closer linear force; got {f_loop}.",
+        )
+
+        # MuJoCo's solver is run with iterations=100 and impratio=100; one
+        # implicit step from rest leaves a tiny residual, dominated by the
+        # solver's constraint tolerance.
+        self.assertLess(
+            np.linalg.norm(residual),
+            1e-2,
+            msg=(
+                f"Linear force balance on pinned body_1 violated.\n"
+                f"  f_gravity = {f_grav}\n"
+                f"  body_parent_f.linear = {f_pin}\n"
+                f"  joint_parent_f.linear = {f_loop}\n"
+                f"  residual = {residual}, |residual| = {np.linalg.norm(residual)}"
+            ),
+        )
+
+
+###
+# Test execution
+###
+
+if __name__ == "__main__":
+    setup_tests()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

Adds prototype for extracting joint wrenches from equality constraint-backed joints from mjwarp.

## Checklist

- [ ] New or existing tests cover these changes
- [ ] The documentation is up to date with these changes
- [ ] `CHANGELOG.md` has been updated (if user-facing change)

## Test plan

<!-- How were these changes verified? Include commands, test names,
     or manual steps. Example:
     ```
     uv run --extra dev -m newton.tests -k test_relevant_test
     ``` -->

## Bug fix

<!-- DELETE this section if not a bug fix.
     Describe how to reproduce the issue WITHOUT this PR applied. -->

**Steps to reproduce:**

<!-- 1. Step one
     2. Step two
     3. Observe incorrect behavior -->

**Minimal reproduction:**

```python
import newton

# Code that demonstrates the bug
```

## New feature / API change

<!-- DELETE this section if not applicable.
     Provide a code example showing what this PR enables. -->

```python
import newton

# Code that demonstrates the new capability
```
